### PR TITLE
removes default role from user and fixes 34 broken assertions

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,8 +5,8 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :trackable, :validatable, :confirmable
 
   before_validation :twitter,
-                    :sanitize_inputs,
-                    :set_role
+                    :sanitize_inputs
+
   validates :twitter,
     length: { maximum: 15 },
     format: {
@@ -71,10 +71,10 @@ class User < ApplicationRecord
     twitter.sub!(/\A@+/,"") if twitter
   end
 
-  def set_role
-    role = Role.find_or_create_by(name: 'enrolled')
-    roles << role
-  end
+  # def set_role
+  #   role = Role.find_or_create_by(name: 'enrolled')
+  #   roles << role
+  # end
 
   def change_role(new_role_name)
     new_role = Role.find_by(name: new_role_name)

--- a/spec/acceptance/filter_users_spec.rb
+++ b/spec/acceptance/filter_users_spec.rb
@@ -4,8 +4,8 @@ RSpec.feature 'Filter users by cohort' do
   scenario 'by selecting cohort from dropdown' do
     cohort   = create(:cohort, name: "1606")
     cohort_2 = create(:cohort, name: "1608")
-    create(:user, cohort_id: cohort.id)
-    user = create(:user, cohort_id: cohort_2.id)
+    create(:enrolled_user, cohort_id: cohort.id)
+    user = create(:enrolled_user, cohort_id: cohort_2.id)
 
     login(user)
 

--- a/spec/acceptance/invited_guest_registers_spec.rb
+++ b/spec/acceptance/invited_guest_registers_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'Invited user' do
   it 'registers an account' do
-    role = create :role, name: 'Mentor'
+    role = create :role, name: 'mentor'
     invite = create :invitation, role: role
     visit invite.generate_url(new_user_registration_url)
 
@@ -19,7 +19,7 @@ RSpec.feature 'Invited user' do
     sign_in user
     visit user_path(user.id)
 
-    expect(user.roles.find_by(name: "Mentor")).to_not be_nil
-    expect(page).to have_content('Mentor')
+    expect(user.roles.find_by(name: "mentor")).to_not be_nil
+    expect(page).to have_content('mentor')
   end
 end

--- a/spec/acceptance/user/creates_affiliations_spec.rb
+++ b/spec/acceptance/user/creates_affiliations_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'User creates affiliations' do
   scenario 'by completing the my affiliations form' do
-    user = create(:user)
+    user = create(:enrolled_user)
     group = create(:group)
     create(:group, name: "LGBTTuring")
     login(user)

--- a/spec/acceptance/user/edit_spec.rb
+++ b/spec/acceptance/user/edit_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'Edit all user attributes' do
   scenario 'by submitting edit user form' do
     cohort_1 = create :cohort
     cohort_2 = create :cohort
-    user   = create( :user,
+    user   = create( :enrolled_user,
                      first_name: "Joe",
                      last_name: "Shmoe",
                      email: "jshmoe@example.com",

--- a/spec/acceptance/user/logs_in_spec.rb
+++ b/spec/acceptance/user/logs_in_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'User logs in' do
   scenario 'by providing email and password' do
-    user = create(:user)
+    user = create(:enrolled_user)
     visit root_path
     fill_in 'Email', with: user.email
     fill_in 'Password', with: user.password

--- a/spec/acceptance/user/logs_out_spec.rb
+++ b/spec/acceptance/user/logs_out_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'User logs out' do
   scenario 'by selecting logout' do
-    user = create(:user)
+    user = create(:enrolled_user)
     login(user)
     click_link 'Logout'
 

--- a/spec/acceptance/user/views_account_info_spec.rb
+++ b/spec/acceptance/user/views_account_info_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'User views account info' do
   scenario 'by visiting user show page' do
-    user = create(:user)
+    user = create(:enrolled_user)
     login(user)
 
     click_link 'Account Info'

--- a/spec/acceptance/user/views_all_users_spec.rb
+++ b/spec/acceptance/user/views_all_users_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'User views account info' do
   scenario 'by visiting user show page' do
-    user = create(:user)
+    user = create(:enrolled_user)
     login(user)
 
     expect(page).to have_content("Users")

--- a/spec/controllers/affiliations_controller_spec.rb
+++ b/spec/controllers/affiliations_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe AffiliationsController, type: :controller do
 
   context 'Logged in user navigates to' do
     before do
-      @user = create :user
+      @user = create :enrolled_user
       sign_in @user
     end
     it 'affiliations#create, they are redirected' do

--- a/spec/controllers/oauth/applications_controller_spec.rb
+++ b/spec/controllers/oauth/applications_controller_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Oauth::ApplicationsController, type: :controller do
 
   context "Logged in user navigates to" do
     before do
-      @user = create :user
+      @user = create :enrolled_user
       sign_in @user
       @app = create :application, owner: @user
     end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe UsersController, type: :controller do
 
   context "Logged in user navigates to" do
     before do
-      @user = create :user
+      @user = create :enrolled_user
       sign_in @user
     end
 

--- a/spec/factories/affiliations.rb
+++ b/spec/factories/affiliations.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :affiliation do
-    user
+    user factory: :enrolled_user
     group
   end
 end

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
   factory :role do
-    name "default"
+    name "enrolled"
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -15,6 +15,12 @@ FactoryGirl.define do
       end
     end
 
+    factory :enrolled_user do
+      after(:create) do |enrolled_user, _ |
+        create_list(:role, 1, name: "enrolled", users: [enrolled_user])
+      end
+    end
+
     factory :user_with_roles do
       after(:create) do | user_with_roles, _ |
         create_list(:role, 2, name: "dummy_role", users: [user_with_roles])

--- a/spec/features/applications/logged_in_user_registers_new_client_oauth_app_spec.rb
+++ b/spec/features/applications/logged_in_user_registers_new_client_oauth_app_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature "Logged In User Registers New Client OAuth App", type: :feature do
   it "they get a client id and client secret" do
-    user = create :user
+    user = create :enrolled_user
     login(user)
 
     visit new_oauth_application_path
@@ -18,7 +18,7 @@ RSpec.feature "Logged In User Registers New Client OAuth App", type: :feature do
   end
 
   it 'sees a useful error if information is missing' do
-    me = create :user
+    me = create :enrolled_user
     sign_in me
 
     visit new_oauth_application_path

--- a/spec/features/applications/user_sees_own_applications_spec.rb
+++ b/spec/features/applications/user_sees_own_applications_spec.rb
@@ -1,18 +1,18 @@
-require 'rails_helper' 
+require 'rails_helper'
 
 RSpec.describe 'Oauth Applications' do
   it 'index shows a list of my applications' do
-    me = create :user
+    me = create :enrolled_user
     sign_in me
     my_application = create :application, owner: me
-    
+
     visit oauth_applications_path
 
     expect(page).to have_content my_application.name
   end
 
   it 'are not visible to other users' do
-    me = create :user
+    me = create :enrolled_user
     sign_in me
     other = create :user
     app = create :application, owner: other

--- a/spec/features/users/view_another_user_spec.rb
+++ b/spec/features/users/view_another_user_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'User profiles' do
   it 'shows another user information' do
-    me = create :user
+    me = create :enrolled_user
     othe = create :user, first_name: 'Andrew', last_name: 'Carmer'
 
     login me
@@ -15,7 +15,7 @@ RSpec.describe 'User profiles' do
   end
 
   it 'prevets another user from editing my infromation' do
-    me = create :user
+    me = create :enrolled_user
     other = create :user, first_name: 'Andrew', last_name: 'Carmer'
 
     login me

--- a/spec/features/users/views_and_edits_profile_spec.rb
+++ b/spec/features/users/views_and_edits_profile_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'User visits edit profile page', js: :true do
   it 'has an edit button' do
-    user = create :user
+    user = create :enrolled_user
     login user
     visit user_path(user)
 
@@ -10,7 +10,7 @@ RSpec.describe 'User visits edit profile page', js: :true do
   end
 
   it 'has a change password button' do
-    user = create :user
+    user = create :enrolled_user
     login user
     visit user_path user
 
@@ -19,7 +19,7 @@ RSpec.describe 'User visits edit profile page', js: :true do
 
   context "they enter an '@' with their twitter username" do
     scenario "that input field turns red, but it is corrected for them" do
-      user = create :user, twitter: ""
+      user = create :enrolled_user, twitter: ""
       login user
 
       visit edit_user_path user
@@ -40,7 +40,7 @@ RSpec.describe 'User visits edit profile page', js: :true do
 
   context "they enter an invalid twitter username" do
     scenario "the update is rejected" do
-      user = create :user, twitter: ""
+      user = create :enrolled_user, twitter: ""
       login user
 
       visit edit_user_path(user)
@@ -56,7 +56,7 @@ RSpec.describe 'User visits edit profile page', js: :true do
 
   context "they enter an invalid LinkedIn username" do
     scenario "they are shown a warning and then the update is rejected" do
-      user = create :user, linked_in: ""
+      user = create :enrolled_user, linked_in: ""
       login user
 
       visit edit_user_path(user)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe User, type: :model do
   end
 
   it "can report out its roles" do
-    user = create :user
+    user = create :enrolled_user
 
     expect(user.list_roles).to eq("enrolled")
   end
@@ -68,12 +68,6 @@ RSpec.describe User, type: :model do
     expect(invalid_characters.valid?).to be false
     expect(too_short.valid?).to be false
     expect(too_long.valid?).to be false
-  end
-
-  it "sets its default role before saving" do
-    user = create(:user)
-
-    expect(user.has_role?('enrolled')).to eq(true)
   end
 
   context 'Role change' do


### PR DESCRIPTION
My interpretation of the projects history:

Originally, there were no roles and the team wrote a test suite assuming that all registered users could do everything. Then cancancan came in and started restricting authorization based on a users role.

```
elsif user.has_role?("mentor") || user.has_role?("active student") || user.has_role?("enrolled")
can :do a_bunch_of_stuff
```

This caused a huge chunk of the test suite to break because they were creating roleless users in the tests and these users no longer had permission to do anything.

Instead of fixing the test suite, a default role of "enrolled" was added to the user. This was a bad decision. User's should not have a default role. They should be assigned their role based on what it actually is.

In my opinion, you shouldn't change your codebase just to make tests pass. You should only add code that has a purpose. So I removed the before_action, created a factory for :enrolled_user and fixed 34 failing assertions in the test suite mostly by changing :user to :enrolled_user. I also discovered some tests along the way that were setting the role "Manager" instead of lowercase "manager", so they were only passing because the default role "enrolled" was being added to users.