### PR TITLE
Js roles makeover

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -100,7 +100,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
         :linked_in,
         :git_hub,
         :slack,
-        :cohort,
+        :cohort_id,
         :password,
         :password_confirmation
       )

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -1,6 +1,7 @@
 class Cohort < ApplicationRecord
   validates :name, presence: true
   has_many :users
+  enum status: [:unstarted, :active, :finished]
 
   def student_count
     users.count

--- a/app/services/ability.rb
+++ b/app/services/ability.rb
@@ -7,7 +7,7 @@ class Ability
 
     if user.has_role?("admin")
       can :manage, :all
-    elsif user.has_role?("mentor") || user.has_role?("active student") || user.has_role?("enrolled")
+    elsif user.has_role?("mentor") || user.has_role?("active student") || user.has_role?("graduated")
       can :create, User
       can :update, User, id: user.id
       can :read, User, id: user.id
@@ -18,6 +18,14 @@ class Ability
       can :create, Affiliation
       can :update, Affiliation
       can :manage, Doorkeeper::Application, owner_id: user.id
+      cannot :manage, Invitation
+    elsif user.has_role?("enrolled")
+      can :create, User
+      can :update, User, id: user.id
+      can :read, User, id: user.id
+      can :read, Cohort
+      can :read, Group
+      can :read, Role
       cannot :manage, Invitation
     elsif user.has_role?("exited") || user.has_role?("removed")
       cannot :manage, :all

--- a/app/services/invitation_manager.rb
+++ b/app/services/invitation_manager.rb
@@ -3,8 +3,8 @@ class InvitationManager
               :bad_emails
 
   def initialize(params, user, url)
-    @role = Role.find_by(name: params[:role])
     @cohort = params[:cohort] || ""
+    @role = find_role(params[:role])
     @emails = params[:email].split(",").map{|e| e.strip}
     @user = user
     @url = url
@@ -26,6 +26,26 @@ class InvitationManager
   end
 
   private
+
+    def find_role(role)
+      case role
+
+      when "Student"
+        case Cohort.find_by(name: @cohort).status
+        when "unstarted"
+          return Role.find_by(name: "enrolled")
+        when "active"
+          return Role.find_by(name: "active student")
+        when "finished"
+          return Role.find_by(name: "graduated")
+        end
+
+      when "Mentor"
+        return Role.find_by(name: "mentor")
+      when "Admin"
+        return Role.find_by(name: "admin")
+      end
+    end
 
     def process_emails
       emails.reduce([]) do |bad_emails, email|

--- a/app/views/invitations/new.html.erb
+++ b/app/views/invitations/new.html.erb
@@ -3,7 +3,7 @@
   <%= f.label :email, "Emails" %>
   <%= f.text_area :email, placeholder: "Comma separated list of email addresses" %>
   <%= label_tag :role %>
-  <%= select_tag :role, options_for_select(["mentor", "invited"]), id: "role-select" %>
+  <%= select_tag :role, options_for_select(["Student", "Mentor", "Admin"]), id: "role-select" %>
   <%= label_tag :cohort %>
   <%= select_tag :cohort, options_for_select(@cohorts), id: "cohort-select" %>
   <%= f.submit "Invite" %>

--- a/db/migrate/20170206234606_add_status_to_cohort.rb
+++ b/db/migrate/20170206234606_add_status_to_cohort.rb
@@ -1,0 +1,5 @@
+class AddStatusToCohort < ActiveRecord::Migration[5.0]
+  def change
+    add_column :cohorts, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170203023051) do
+ActiveRecord::Schema.define(version: 20170206234606) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,8 +26,9 @@ ActiveRecord::Schema.define(version: 20170203023051) do
 
   create_table "cohorts", force: :cascade do |t|
     t.string   "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
+    t.integer  "status",     default: 0
   end
 
   create_table "groups", force: :cascade do |t|
@@ -126,6 +127,7 @@ ActiveRecord::Schema.define(version: 20170203023051) do
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
     t.string   "slack"
+    t.string   "cohort"
     t.string   "twitter"
     t.string   "linked_in"
     t.string   "git_hub"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -24,15 +24,13 @@ Cohort.create(name: "1608-FE")
 Cohort.create(name: "1610-BE")
 Cohort.create(name: "1610-FE")
 
-["applicant", "invited", "enrolled", "active student",
- "on leave", "graduated", "exited", "removed", "mentor", "admin"].each do |role|
+["enrolled", "active student", "graduated", "exited", "removed", "mentor", "admin"].each do |role|
    Role.find_or_create_by(name: role)
    p "Role #{Role.last.id} has been created with name #{Role.last.name}"
  end
 
 active_student = Role.find_by(name: "active student")
 admin = Role.find_by(name: "admin")
-applicant = Role.find_by(name: "applicant")
 
 cohort_1608.each do |person|
   first_name = person.split.first
@@ -61,16 +59,6 @@ admin_user = User.new({
 })
 admin_user.roles << admin
 admin_user.save
-
-applicant_user = User.new({
-  first_name: "Wanna",
-  last_name: "Be",
-  email: "wannabe@example.com",
-  password: "password",
-  confirmed_at: DateTime.new()
-})
-applicant_user.roles << applicant
-applicant_user.save
 
 accordian = User.new({
   first_name: "Accordian",

--- a/spec/acceptance/admin/invites_user_spec.rb
+++ b/spec/acceptance/admin/invites_user_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'Invitations' do
     expect(current_path).to eq(new_invitation_path)
 
     fill_in 'Emails', with: 'email1@example.com, email2@example.com'
-    select 'mentor', from: 'role'
+    select 'Mentor', from: 'role'
     click_button "Invite"
 
     expect(current_path).to eq(invitations_path)

--- a/spec/acceptance/user/creates_affiliations_spec.rb
+++ b/spec/acceptance/user/creates_affiliations_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'User creates affiliations' do
   scenario 'by completing the my affiliations form' do
 
-    user = create(:enrolled_user)
+    user = create(:active_student)
     group = create(:group, name: "Armstrong")
     create(:group, name: "LGBTTuring")
     login(user)

--- a/spec/controllers/affiliations_controller_spec.rb
+++ b/spec/controllers/affiliations_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe AffiliationsController, type: :controller do
 
   context 'Logged in user navigates to' do
     before do
-      @user = create :enrolled_user
+      @user = create :active_student
       sign_in @user
     end
     it 'affiliations#create, they are redirected' do

--- a/spec/controllers/oauth/applications_controller_spec.rb
+++ b/spec/controllers/oauth/applications_controller_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Oauth::ApplicationsController, type: :controller do
 
   context "Logged in user navigates to" do
     before do
-      @user = create :enrolled_user
+      @user = create :active_student
       sign_in @user
       @app = create :application, owner: @user
     end

--- a/spec/factories/affiliations.rb
+++ b/spec/factories/affiliations.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :affiliation do
-    user factory: :enrolled_user
+    user factory: :active_student
     group
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -15,6 +15,12 @@ FactoryGirl.define do
       end
     end
 
+    factory :active_student do
+      after(:create) do |active_student, _ |
+        create_list(:role, 1, name: "active student", users: [active_student])
+      end
+    end
+
     factory :enrolled_user do
       after(:create) do |enrolled_user, _ |
         create_list(:role, 1, name: "enrolled", users: [enrolled_user])

--- a/spec/features/applications/logged_in_user_registers_new_client_oauth_app_spec.rb
+++ b/spec/features/applications/logged_in_user_registers_new_client_oauth_app_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature "Logged In User Registers New Client OAuth App", type: :feature do
   it "they get a client id and client secret" do
-    user = create :enrolled_user
+    user = create :active_student
     login(user)
 
     visit new_oauth_application_path
@@ -18,7 +18,7 @@ RSpec.feature "Logged In User Registers New Client OAuth App", type: :feature do
   end
 
   it 'sees a useful error if information is missing' do
-    me = create :enrolled_user
+    me = create :active_student
     sign_in me
 
     visit new_oauth_application_path

--- a/spec/features/applications/user_sees_own_applications_spec.rb
+++ b/spec/features/applications/user_sees_own_applications_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Oauth Applications' do
   it 'index shows a list of my applications' do
-    me = create :enrolled_user
+    me = create :active_student
     sign_in me
     my_application = create :application, owner: me
 
@@ -12,7 +12,7 @@ RSpec.describe 'Oauth Applications' do
   end
 
   it 'are not visible to other users' do
-    me = create :enrolled_user
+    me = create :active_student
     sign_in me
     other = create :user
     app = create :application, owner: other

--- a/spec/features/invites/invitation_does_not_save_spec.rb
+++ b/spec/features/invites/invitation_does_not_save_spec.rb
@@ -8,23 +8,11 @@ RSpec.feature "Invitation is malformed" do
     visit new_invitation_path
 
     fill_in "Emails", with: "bad_email, good@example.com, bad_example.com"
-    select 'mentor', from: 'role'
+    select 'Mentor', from: 'role'
 
     click_button "Invite"
 
     expect(current_path).to eq(new_invitation_path)
     expect(page).to have_content("1 out of 3 invites sent. Error sending bad_email, bad_example.com.")
-  end
-
-  it "displays an error if no group is selected" do
-    admin = create :admin
-    sign_in admin
-    visit new_invitation_path
-
-    fill_in "Emails", with: "good@example.com"
-    click_button "Invite"
-
-    expect(current_path).to eq(new_invitation_path)
-    expect(page).to have_content("Select a role.")
   end
 end

--- a/spec/services/ability_spec.rb
+++ b/spec/services/ability_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'User abilities:' do
   context 'enrolled or active student user' do
     it 'can manage most functionality' do
       user = create :user
-      random_role = ['enrolled', 'active student'].shuffle.pop
+      random_role = ['graduated', 'active student'].shuffle.pop
       role = create :role, name: "#{random_role}"
       user.roles << role
       ability = Ability.new(user)

--- a/spec/services/invitation_manager_spec.rb
+++ b/spec/services/invitation_manager_spec.rb
@@ -6,30 +6,30 @@ RSpec.describe InvitationManager do
 
   let(:invitation_params) do
     { email: "bad_email, good@example.com, bad_example.com",
-      role: "mentor" }
+      role: "Mentor" }
   end
 
   let(:no_space_invitation_params) do
     { email: "this@example.com,that@example.com",
-      role: "mentor" }
+      role: "Mentor" }
   end
 
   let(:space_before_comma_params) do
     { email: "this@example.com , that@example.com",
-      role: "mentor" }
+      role: "Mentor" }
   end
 
   let(:one_email_with_comma) do
     { email: "this@example.com,",
-      role: "mentor" }
+      role: "Mentor" }
   end
 
   let(:good_params) do
-    { email: "good@example.com", role: "mentor" }
+    { email: "good@example.com", role: "Mentor" }
   end
 
   let(:cohort_params) do
-    { email: "good@example.com", role: "mentor", cohort: "1608-BE" }
+    { email: "good@example.com", role: "Mentor", cohort: "1608-BE" }
   end
 
   let(:user) { create :admin }

--- a/spec/services/invitation_manager_spec.rb
+++ b/spec/services/invitation_manager_spec.rb
@@ -2,6 +2,9 @@ require 'rails_helper'
 
 RSpec.describe InvitationManager do
   before(:each) { create :role, name: "mentor" }
+  before(:each) { create :role, name: "active student" }
+  before(:each) { create :role, name: "enrolled" }
+  before(:each) { create :role, name: "graduated" }
   before(:each) { create :cohort, name: "1608-BE" }
 
   let(:invitation_params) do
@@ -99,6 +102,33 @@ RSpec.describe InvitationManager do
 
     expect(manager.status).to eq(:error)
     expect(manager.success?).to eq(false)
+  end
+
+  it "sets role to enrolled if student and unstarted cohort" do
+    params = { email: "good@example.com", role: "Student", cohort: "1703-FE" }
+    cohort = create(:cohort, name: "1703-FE", status: "unstarted")
+    manager = InvitationManager.new(params, user, url)
+    invite = Invitation.first
+
+    expect(invite.role.name).to eq("enrolled")
+  end
+
+  it "sets role to active student if student and active cohort" do
+    params = { email: "good@example.com", role: "Student", cohort: "1703-FE" }
+    cohort = create(:cohort, name: "1703-FE", status: "active")
+    manager = InvitationManager.new(params, user, url)
+    invite = Invitation.first
+
+    expect(invite.role.name).to eq("active student")
+  end
+
+  it "sets role to graduated if student and finished cohort" do
+    params = { email: "good@example.com", role: "Student", cohort: "1703-FE" }
+    cohort = create(:cohort, name: "1703-FE", status: "finished")
+    manager = InvitationManager.new(params, user, url)
+    invite = Invitation.first
+
+    expect(invite.role.name).to eq("graduated")
   end
 
   it "returns a notice if all invitations are created" do


### PR DESCRIPTION
Cohorts now have a status enum: [:unstarted, :active, :finished]

When an admin sends an invitation, they can select role from ["Admin", "Mentor", "Student"].

If they select student, the new user will be given a role of "enrolled", "active student" or "graduated" depending on the status of the cohort.

I sorted out the permissions in the ability.rb file to reflect what we were talking about earlier.