### PR TITLE
Js admin can manager cohort status

### DIFF
--- a/app/controllers/admin/cohorts_controller.rb
+++ b/app/controllers/admin/cohorts_controller.rb
@@ -44,7 +44,7 @@ class Admin::CohortsController < ApplicationController
   private
 
   def cohort_params
-    params.require(:cohort).permit(:name)
+    params.permit(:name, :status)
   end
 
   def set_cohort

--- a/app/controllers/admin/cohorts_controller.rb
+++ b/app/controllers/admin/cohorts_controller.rb
@@ -26,6 +26,7 @@ class Admin::CohortsController < ApplicationController
   end
 
   def update
+    @cohort.update_student_roles(params[:status]) if params[:status]
     if @cohort.update_attributes(cohort_params)
       redirect_to admin_cohorts_path
     else

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -6,4 +6,23 @@ class Cohort < ApplicationRecord
   def student_count
     users.count
   end
+
+  def update_student_roles(new_status)
+    old_role = status_key[status]
+    users.joins(:roles)
+    .where(roles: {name: old_role.name})
+    .each do |user|
+      user.roles << status_key[new_status]
+      user.roles.delete(old_role)
+      user.save
+    end
+  end
+
+  private
+
+    def status_key
+      { "unstarted" => Role.find_by(name:"enrolled"),
+        "active" => Role.find_by(name:"active student"),
+        "finished" => Role.find_by(name:"graduated") }
+    end
 end

--- a/app/views/shared/_cohorts_table.html.erb
+++ b/app/views/shared/_cohorts_table.html.erb
@@ -10,6 +10,11 @@
       <td><%= cohort.student_count %></td>
       <td>
         <div class="btn-group" role="group">
+          <% if cohort.status == "unstarted" %>
+            <%= link_to "Start", "", class: "btn btn-warning" %>
+          <% elsif cohort.status == "active" %>
+            <%= link_to "Finish", "", class: "btn btn-warning" %>
+          <% end %>
           <%= link_to "Edit",
               edit_admin_cohort_path(cohort),
               class: 'btn btn-default' %>

--- a/app/views/shared/_cohorts_table.html.erb
+++ b/app/views/shared/_cohorts_table.html.erb
@@ -2,18 +2,20 @@
   <tr>
     <th>Name</th>
     <th># of Students</th>
+    <th>Status</th>
     <th>Actions</th>
   </tr>
   <% cohorts.each do |cohort| %>
     <tr class="cohort">
       <td><%= cohort.name %></td>
       <td><%= cohort.student_count %></td>
+      <td><%= cohort.status %></td>
       <td>
         <div class="btn-group" role="group">
           <% if cohort.status == "unstarted" %>
-            <%= link_to "Start", "", class: "btn btn-warning" %>
+            <%= link_to "Start", admin_cohort_path(cohort, status: "active"), method: 'put', class: "btn btn-warning" %>
           <% elsif cohort.status == "active" %>
-            <%= link_to "Finish", "", class: "btn btn-warning" %>
+            <%= link_to "Finish", admin_cohort_path(cohort, status: "finished"), method: 'put', class: "btn btn-warning" %>
           <% end %>
           <%= link_to "Edit",
               edit_admin_cohort_path(cohort),

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,8 +1,8 @@
 Doorkeeper::Application.create(name: "Monocle", redirect_uri: "http://localhost:3001/auth/census/callback", scopes: '')
 
+Invitation.destroy_all
 User.destroy_all
 Affiliation.destroy_all
-Invitation.destroy_all
 Cohort.destroy_all
 Group.destroy_all
 Role.destroy_all

--- a/spec/features/admins/admin_can_update_cohort_status_spec.rb
+++ b/spec/features/admins/admin_can_update_cohort_status_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.feature "Admin user" do
+  it "can update the status of a cohort" do
+
+    create :role, name: "active student"
+    create :role, name: "graduated"
+    create :role, name: "enrolled"
+    admin = create :admin
+    sign_in admin
+    visit(admin_cohorts_path)
+
+    click_on "Start"
+    expect(page).to have_link("Finish")
+    expect(Cohort.first.status).to eq("active")
+
+    click_on "Finish"
+    expect(Cohort.first.status).to eq("finished")
+  end
+end

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -13,4 +13,27 @@ RSpec.describe Cohort, type: :model do
 
     expect(cohort.student_count).to eq(3)
   end
+
+  it "can update student roles" do
+    cohort = create :cohort, name: "1608-BE"
+    user = create :enrolled_user, cohort: cohort
+    create :role, name: "active student"
+    create :role, name: "graduated"
+
+    cohort.update_student_roles("active")
+    expect(user.roles.first.name).to eq("active student")
+  end
+
+  it "doesn't update students with wonky roles" do
+    cohort = create :cohort, name: "1608-BE"
+    create :role, name: "active student"
+    create :role, name: "graduated"
+    create :role, name: "enrolled"
+    exited = create :role, name: "exited"
+    user = create :user, cohort: cohort
+    user.roles << exited
+
+    cohort.update_student_roles("active")
+    expect(user.roles.first.name).to eq("exited")
+  end
 end


### PR DESCRIPTION
Admins can now click "start" on an "unstarted" cohort to change the status to "active." All students belonging to that cohort with the current role of "enrolled" will be upgrade to "active student".

Admins can now click "finish" on an "active" cohort to change the status to "finished." All students belonging to that cohort with the current role of "active student" will be upgraded to "graduated".