### PR TITLE
user can only have a role once

### DIFF
--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -1,4 +1,6 @@
 class UserRole < ApplicationRecord
+  validates_uniqueness_of :user_id, scope: :role_id
+
   belongs_to :user
   belongs_to :role
 end


### PR DESCRIPTION
I can't figure out how to test this validation. Shoulda Matchers says you can use `should validate_uniqueness_of :user_id, scope: :role_id`, but that blows up. So I tried to add a role to a user twice and expect the second time to raise an error, but that also blows up. But it definitely prevents a user from having 2 of the same role.