### PR TITLE
admin security loopholes plugged

### DIFF
--- a/app/controllers/admin/cohorts_controller.rb
+++ b/app/controllers/admin/cohorts_controller.rb
@@ -1,4 +1,4 @@
-class Admin::CohortsController < ApplicationController
+class Admin::CohortsController < AdminController
   before_action :set_cohort, only: [:show, :update, :destroy, :edit]
 
   def index

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,4 +1,4 @@
-class Admin::DashboardController < ApplicationController
+class Admin::DashboardController < AdminController
   def show
 
   end

--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -1,4 +1,4 @@
-class Admin::GroupsController < ApplicationController
+class Admin::GroupsController < AdminController
 
   def index
     @groups = Group.all

--- a/app/controllers/admin/roles/users_controller.rb
+++ b/app/controllers/admin/roles/users_controller.rb
@@ -1,4 +1,4 @@
-class Admin::Roles::UsersController < ApplicationController
+class Admin::Roles::UsersController < AdminController
   def edit
     @roles = Role.all
   end

--- a/app/controllers/admin/roles_controller.rb
+++ b/app/controllers/admin/roles_controller.rb
@@ -1,4 +1,4 @@
-class Admin::RolesController < ApplicationController
+class Admin::RolesController < AdminController
 
   def index
     @roles = Role.all

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,4 +1,4 @@
-class Admin::UsersController < ApplicationController
+class Admin::UsersController < AdminController
   def update
     @user = User.find_by(id: params[:id])
     if @user.change_role(params[:role])

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,0 +1,9 @@
+class AdminController < ApplicationController
+  before_action :is_admin?
+
+  def is_admin?
+    unless current_user && current_user.roles.where(name: 'admin').exists?
+      render :file => 'public/404.html', :status => :not_found, :layout => false
+    end
+  end
+end

--- a/spec/features/admins/admin_updates_users_roles_spec.rb
+++ b/spec/features/admins/admin_updates_users_roles_spec.rb
@@ -4,11 +4,13 @@ RSpec.describe "Admin updates users' roles" do
   context "they visit admin/roles/users" do
     it "displays a form for updating users" do
       role_1, role_2, role_3 = create_list(:role, 3)
+      admin = create :admin
       users = create_list(:user, 3)
       users.first.roles << role_1
       users.second.roles << role_1
       users.second.roles << role_2
 
+      login admin
       visit admin_roles_users_edit_path
 
       expect(page).to have_content("Find")


### PR DESCRIPTION
All admin requests now get routed through `AdminController`, which confirms that the user `is_admin?`