### PR TITLE
invite people as staff not admins

### DIFF
--- a/app/views/invitations/new.html.erb
+++ b/app/views/invitations/new.html.erb
@@ -4,7 +4,7 @@
     <%= f.label :email, "Emails" %>
     <%= f.text_area :email, placeholder: "Comma separated list of email addresses", class: "form-control emails-input" %>
     <%= label_tag :role %>
-    <%= select_tag :role, options_for_select(["Student", "Mentor", "Admin"]), id: "role-select", class: "pretty-select" %>
+    <%= select_tag :role, options_for_select(["Student", "Staff", "Mentor"]), id: "role-select", class: "pretty-select" %>
     <%= label_tag :cohort %>
     <%= select_tag :cohort, options_for_select(@cohorts), id: "cohort-select", class: "pretty-select" %>
     <%= f.submit "Invite", class: 'btn btn-warning btn-xs' %>


### PR DESCRIPTION
Somehow this got changed in the styling 2 15 pull request. It made it all the way to production, so we need to merge this asap because it breaks the invitation process.