### PR TITLE
Paperclip no longer needs S3 in development environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,14 @@ Census is built to expect a certain number of environment variables. We suggest 
 You will need an AWS S3 Bucket, Access Key ID, a Secret Access Key and an AWS region defined. Use the [AWS SDK](https://github.com/aws/aws-sdk-ruby) gem to get started.
 
 Environment Variables:
-```
-SALT # used for salting email invite tokens
+
+```yaml
+SALT # used for salting email invite tokens. Can be any random string.
 MY_EMAIL # used for testing purposes. Can be any email.
-S3_BUCKET_NAME
-AWS_ACCESS_KEY_ID
-AWS_SECRET_ACCESS_KEY
-AWS_REGION
+S3_BUCKET_NAME # Not needed in development
+AWS_ACCESS_KEY_ID # Not needed in development
+AWS_SECRET_ACCESS_KEY # Not needed in development
+AWS_REGION # Not needed in development
 ```
 
 ### [Paperclip Gem](#paperclip)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,13 +59,4 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.paperclip_defaults = {
-    storage: :s3,
-    s3_credentials: {
-      bucket: ENV.fetch('S3_BUCKET_NAME'),
-      access_key_id: ENV.fetch('AWS_ACCESS_KEY_ID'),
-      secret_access_key: ENV.fetch('AWS_SECRET_ACCESS_KEY'),
-      s3_region: ENV.fetch('AWS_REGION'),
-    }
-  }
 end


### PR DESCRIPTION
I've removed the S3 config from `config/environments/development.rb`. In the development environment, paperclip will just use the file system instead of S3. We did this on a previous project I worked on, and it worked really well. Makes it a lot easier for people to get up and running and contributing.