### PR TITLE
Add find by github endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,11 @@ To receive your own user credentials:
 GET 'https://census-app-staging/api/v1/user_credentials'
 ```
 
+To receive a user's credentials by github username:
+```
+GET 'https://census-app-staging/api/v1/find_by_github?q=github_username'
+```
+
 The user endpoints return JSON in this format:
 ```
 {

--- a/app/controllers/api/v1/users/by_github_controller.rb
+++ b/app/controllers/api/v1/users/by_github_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::Users::ByGithubController < Api::V1::ApiController
     if params[:q] && user = User.find_by(git_hub: params[:q])
       render json: user, serializer: UserSerializer, status: 200
     else
-      render json: "User not found with github username #{params[:q]}", status: 404
+      render json: { error: "User not found" }, status: 404
     end
   end
 end

--- a/app/controllers/api/v1/users/by_github_controller.rb
+++ b/app/controllers/api/v1/users/by_github_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::Users::FindByGithubController < Api::V1::ApiController
+class Api::V1::Users::ByGithubController < Api::V1::ApiController
   before_action :doorkeeper_authorize!
 
   def show

--- a/app/controllers/api/v1/users/find_by_github_controller.rb
+++ b/app/controllers/api/v1/users/find_by_github_controller.rb
@@ -1,0 +1,11 @@
+class Api::V1::Users::FindByGithubController < Api::V1::ApiController
+  before_action :doorkeeper_authorize!
+
+  def show
+    if params[:q] && user = User.find_by(git_hub: params[:q])
+      render json: user, serializer: UserSerializer, status: 200
+    else
+      render json: "User not found with github username #{params[:q]}", status: 404
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
       namespace :users do
         get '/by_name', to: 'by_name#index'
         get '/by_cohort', to: 'by_cohort#index'
+        get '/find_by_github', to: 'find_by_github#show'
 
         get '/search_all', to: 'search_all#index'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
       namespace :users do
         get '/by_name', to: 'by_name#index'
         get '/by_cohort', to: 'by_cohort#index'
-        get '/find_by_github', to: 'find_by_github#show'
+        get '/by_github', to: 'by_github#show'
 
         get '/search_all', to: 'search_all#index'
 

--- a/spec/requests/api/v1/github_find_request_spec.rb
+++ b/spec/requests/api/v1/github_find_request_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Github find API' do
-  context 'GET api/v1/users/find_by_github' do
+  context 'GET api/v1/users/by_github' do
 
     let(:user)  {create(:user, git_hub: 'username')}
     let(:token) {create(:access_token, resource_owner_id: user.id).token}
@@ -9,7 +9,7 @@ RSpec.describe 'Github find API' do
     context '_with_ authorization credentials' do
       context 'with one match to github username' do
         it 'returns match' do
-          get '/api/v1/users/find_by_github?q=username', params: {access_token: token}
+          get '/api/v1/users/by_github?q=username', params: {access_token: token}
 
           expect(response).to be_success
 
@@ -24,7 +24,7 @@ RSpec.describe 'Github find API' do
       context 'with multiple matches to github username' do
         it 'returns first match' do
           other_user = create(:user, git_hub: 'username')
-          get '/api/v1/users/find_by_github?q=username', params: {access_token: token}
+          get '/api/v1/users/by_github?q=username', params: {access_token: token}
 
           expect(response).to be_success
 
@@ -38,7 +38,7 @@ RSpec.describe 'Github find API' do
 
       context 'with no matches to github username' do
         it 'returns a 404 (not found) status' do
-          get '/api/v1/users/find_by_github?q=name', params: {access_token: token}
+          get '/api/v1/users/by_github?q=name', params: {access_token: token}
 
           expect(response.status).to eq 404
         end
@@ -46,7 +46,7 @@ RSpec.describe 'Github find API' do
 
       context 'with invalid parameters' do
         it 'returns a 404 (not found) status' do
-          get '/api/v1/users/find_by_github?s=username', params: {access_token: token}
+          get '/api/v1/users/by_github?s=username', params: {access_token: token}
 
           expect(response.status).to eq 404
         end
@@ -55,7 +55,7 @@ RSpec.describe 'Github find API' do
   
     context '_without_ authorization credentials' do
       it 'returns a 401 (unauthorized) status' do
-        get '/api/v1/users/find_by_github?q=username'
+        get '/api/v1/users/by_github?q=username'
 
         expect(response.status).to eq 401
       end

--- a/spec/requests/api/v1/github_find_request_spec.rb
+++ b/spec/requests/api/v1/github_find_request_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe 'Github find API' do
+  context 'GET api/v1/users/find_by_github' do
+
+    let(:user)  {create(:user, git_hub: 'username')}
+    let(:token) {create(:access_token, resource_owner_id: user.id).token}
+
+    context '_with_ authorization credentials' do
+      context 'with one match to github username' do
+        it 'returns match' do
+          get '/api/v1/users/find_by_github?q=username', params: {access_token: token}
+
+          expect(response).to be_success
+
+          response_user = JSON.parse(response.body)
+
+          expect(response_user).to be_a Hash
+          expect(response_user['id']).to eq user.id
+          expect(response_user['last_name']).to eq user.last_name
+        end
+      end
+    
+      context 'with multiple matches to github username' do
+        it 'returns first match' do
+          other_user = create(:user, git_hub: 'username')
+          get '/api/v1/users/find_by_github?q=username', params: {access_token: token}
+
+          expect(response).to be_success
+
+          response_user = JSON.parse(response.body)
+
+          expect(response_user).to be_a Hash
+          expect(response_user['id']).to eq other_user.id
+          expect(response_user['last_name']).to eq other_user.last_name
+        end
+      end
+
+      context 'with no matches to github username' do
+        it 'returns a 404 (not found) status' do
+          get '/api/v1/users/find_by_github?q=name', params: {access_token: token}
+
+          expect(response.status).to eq 404
+        end
+      end
+
+      context 'with invalid parameters' do
+        it 'returns a 404 (not found) status' do
+          get '/api/v1/users/find_by_github?s=username', params: {access_token: token}
+
+          expect(response.status).to eq 404
+        end
+      end
+    end
+  
+    context '_without_ authorization credentials' do
+      it 'returns a 401 (unauthorized) status' do
+        get '/api/v1/users/find_by_github?q=username'
+
+        expect(response.status).to eq 401
+      end
+    end
+  end
+end
+
+
+


### PR DESCRIPTION
@neight-allen Although oauth with census is not going to pan out with our react we are hoping to still be able to hit census with a user's github username and get their census data (since we need cohorts).

So our idea was to save their github username and then hit census to retrieve that user's cohort data (and then have a rake task to automatically update cohorts once per module).

I added and tested the following endpoint to census to help us facilitate that so let me know what you think. My main remaining question is how our application could get a census api token to have access to hit the census API.

-Endpoint: `/api/v1/users/find_by_github?q=username`
-Return first match of github username since no two census users should
have the same github username
-Return 404 when no user is found or search params are invalid