### PR TITLE
Add MIT license

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,4 +250,5 @@ Roles are changed according to cohort status. For example, when an active cohort
 `TODO:` Add a CONTRIBUTING.md
 
 ## [License](#license)
-`TODO:` Add a license.md
+
+Census is released under the [MIT License](http://www.opensource.org/licenses/MIT).


### PR DESCRIPTION
@AliSchlereth @neight-allen 

Adds MIT license to bottom of README.

This is consistent with the [Rails README](https://github.com/rails/rails/blob/master/README.md). It appears that the linked file might indicate that there is some template text to be filled out/edited and copied/pasted directly into the document (R. Martinez may have more insight), but if it's good enough for Rails...