### PR TITLE
As add gender

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -98,21 +98,23 @@ class Users::RegistrationsController < Devise::RegistrationsController
     def invitation(code)
       @invitation ||= Invitation.find_by(invitation_code: code)
     end
+
     def invited_user_params
       params.require(:user).permit(
-        :email,
-        :first_name,
-        :last_name,
-        :twitter,
-        :linked_in,
-        :git_hub,
-        :slack,
-        :cohort_id,
-        :password,
-        :password_confirmation,
-        :image,
-        :stackoverflow
-      )
+                                    :email,
+                                    :first_name,
+                                    :last_name,
+                                    :twitter,
+                                    :linked_in,
+                                    :git_hub,
+                                    :slack,
+                                    :cohort_id,
+                                    :password,
+                                    :password_confirmation,
+                                    :image,
+                                    :stackoverflow,
+                                    :gender_pronouns
+                                    )
     end
 
     def valid_invitation_code?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -40,7 +40,8 @@ class UsersController < ApplicationController
                                     :slack,
                                     :cohort_id,
                                     :image,
-                                    :stackoverflow )
+                                    :stackoverflow,
+                                    :gender_pronouns )
     end
 
     def set_user

--- a/app/views/shared/_registration_fields.html.erb
+++ b/app/views/shared/_registration_fields.html.erb
@@ -25,6 +25,13 @@
 
 <div class="form-group">
   <div class="field">
+    <%= f.label :gender_pronouns, "Gender Pronoun(s)" %><br />
+      <%= f.text_field :gender_pronouns, class: "form-control", id: "gender_pronouns-field", placeholder: "E.g. she/her" %><br />
+  </div>
+</div>
+
+<div class="form-group">
+  <div class="field">
     <%= f.label :twitter %>  <span id="twitter-hint" class="bg-danger hidden" style="font-style:italic;">(Enter username only. E.g. for "@j3" enter only "j3")</span><br />
     <%= f.text_field :twitter, class: "form-control", id: "twitter-field", placeholder: "E.g. j3" %><br />
   </div>

--- a/app/views/shared/_registration_fields.html.erb
+++ b/app/views/shared/_registration_fields.html.erb
@@ -26,7 +26,7 @@
 <div class="form-group">
   <div class="field">
     <%= f.label :gender_pronouns, "Gender Pronoun(s)" %><br />
-      <%= f.text_field :gender_pronouns, class: "form-control", id: "gender_pronouns-field", placeholder: "E.g. she/her" %><br />
+    <%= f.text_field :gender_pronouns, class: "form-control", id: "gender_pronouns-field", placeholder: "E.g. she/her" %><br />
   </div>
 </div>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -15,6 +15,9 @@
         header: "Email",
         data: @user.email %>
     <%= render 'account_profile_row',
+        header: "Gender Pronoun(s)",
+        data: @user.gender_pronouns %>
+    <%= render 'account_profile_row',
         header: "Slack",
         data: @user.slack %>
     <%= render 'account_profile_row',

--- a/db/migrate/20170915191929_add_gender_pronouns_to_users.rb
+++ b/db/migrate/20170915191929_add_gender_pronouns_to_users.rb
@@ -1,0 +1,5 @@
+class AddGenderPronounsToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :gender_pronouns, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170223005124) do
+ActiveRecord::Schema.define(version: 20170915191929) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -137,6 +137,7 @@ ActiveRecord::Schema.define(version: 20170223005124) do
     t.datetime "image_updated_at"
     t.integer  "cohort_id"
     t.string   "stackoverflow"
+    t.string   "gender_pronouns"
     t.index ["cohort_id"], name: "index_users_on_cohort_id", using: :btree
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/spec/features/users/basic_registration_spec.rb
+++ b/spec/features/users/basic_registration_spec.rb
@@ -77,8 +77,7 @@ RSpec.feature 'User signs up' do
     fill_in 'Last Name*', with: 'Casimir'
     fill_in 'Password*', with: 'password'
     fill_in 'Password Confirmation*', with: 'password'
-    fill_in 'Gender Pronoun(s)', with: 'she/her'
-    
+    fill_in 'user[gender_pronouns]', with: 'she/her'
     click_button 'Sign up'
 
     new_user = User.last

--- a/spec/features/users/basic_registration_spec.rb
+++ b/spec/features/users/basic_registration_spec.rb
@@ -37,4 +37,33 @@ RSpec.feature 'User signs up' do
     expect(page).to have_content(error_message)
     expect(User.count).to eq(0)
   end
+
+  scenario 'they see all input fields' do
+    role = create :role, name: 'Staff'
+    invite = create :invitation, role: role
+
+    visit invite.generate_url(new_user_registration_url)
+
+    expect(page).to have_content("Gender Pronoun(s)")
+    expect(page.find_field("gender_pronouns-field")).to be_truthy
+
+    expect(page).to have_content("Twitter")
+    expect(page.find_field("twitter-field")).to be_truthy
+
+    expect(page).to have_content("LinkedIn")
+    expect(page.find_field("linkedin-field")).to be_truthy
+
+    expect(page).to have_content("GitHub")
+    expect(page.find_field("github-field")).to be_truthy
+
+    expect(page).to have_content("Slack")
+    expect(page.find_field("slack-field")).to be_truthy
+
+    expect(page).to have_content("StackOverflow")
+    expect(page.find_field("stack_overflow-field")).to be_truthy
+
+    expect(page).to have_content("Cohort")
+    expect(page).to have_content("Upload an image")
+  end
+
 end

--- a/spec/features/users/basic_registration_spec.rb
+++ b/spec/features/users/basic_registration_spec.rb
@@ -83,7 +83,7 @@ RSpec.feature 'User signs up' do
     new_user = User.last
     expect(new_user.first_name).to eq('Jeff')
     expect(new_user.last_name).to eq('Casimir')
-    # expect(new_user.gender_pronouns).to eq("she/her")
+    expect(new_user.gender_pronouns).to eq("she/her")
   end
 
 end

--- a/spec/features/users/basic_registration_spec.rb
+++ b/spec/features/users/basic_registration_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature 'User signs up' do
     fill_in 'Last Name*', with: 'Casimir'
     fill_in 'Password*', with: 'password'
     fill_in 'Password Confirmation*', with: 'password'
+
     click_button 'Sign up'
 
     help_message = 'You have succesfully signed up!'
@@ -64,6 +65,26 @@ RSpec.feature 'User signs up' do
 
     expect(page).to have_content("Cohort")
     expect(page).to have_content("Upload an image")
+  end
+
+  scenario "and enters some pronouns" do
+    role = create :role, name: 'Mentor'
+    invite = create :invitation, role: role
+
+    visit invite.generate_url(new_user_registration_url)
+
+    fill_in 'First Name*', with: 'Jeff'
+    fill_in 'Last Name*', with: 'Casimir'
+    fill_in 'Password*', with: 'password'
+    fill_in 'Password Confirmation*', with: 'password'
+    fill_in 'Gender Pronoun(s)', with: 'she/her'
+    
+    click_button 'Sign up'
+
+    new_user = User.last
+    expect(new_user.first_name).to eq('Jeff')
+    expect(new_user.last_name).to eq('Casimir')
+    # expect(new_user.gender_pronouns).to eq("she/her")
   end
 
 end

--- a/spec/features/users/views_and_edits_profile_spec.rb
+++ b/spec/features/users/views_and_edits_profile_spec.rb
@@ -76,4 +76,16 @@ RSpec.describe 'User visits edit profile page', js: :true do
       expect(page).to have_text("Linked in accepts only alphanumeric characters")
     end
   end
+
+  context "they have a gender pronoun" do
+    it "is listed on the profile page" do
+      user = create :enrolled_user, gender_pronouns: "they/them"
+
+      login user
+
+      visit user_path(user)
+
+      expect(page).to have_content("they/them")
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -47,32 +47,39 @@ RSpec.describe User, type: :model do
 
     expect(users.sort).to eq([dan, nate])
   end
+  context 'add identifying information' do
+    it "rejects invalid twitter usernames" do
+      okay = build(:user, twitter: "_calaway_")
+      invalid_characters = build(:user, twitter: "_ca!away_")
+      too_long = build(:user, twitter: "1234567890123456")
 
-  it "rejects invalid twitter usernames" do
-    okay = build(:user, twitter: "_calaway_")
-    invalid_characters = build(:user, twitter: "_ca!away_")
-    too_long = build(:user, twitter: "1234567890123456")
+      expect(okay.valid?).to be true
+      expect(invalid_characters.valid?).to be false
+      expect(too_long.valid?).to be false
+    end
 
-    expect(okay.valid?).to be true
-    expect(invalid_characters.valid?).to be false
-    expect(too_long.valid?).to be false
-  end
+    it "rejects invalid LinkedIn usernames" do
+      okay = build(:user, linked_in: "calaway")
+      invalid_characters = build(:user, linked_in: "ca!away_")
+      too_short = build(:user, linked_in: "1234")
+      too_long = build(:user, linked_in: "1234567890123456789012345678901")
 
-  it "rejects invalid LinkedIn usernames" do
-    okay = build(:user, linked_in: "calaway")
-    invalid_characters = build(:user, linked_in: "ca!away_")
-    too_short = build(:user, linked_in: "1234")
-    too_long = build(:user, linked_in: "1234567890123456789012345678901")
+      expect(okay.valid?).to be true
+      expect(invalid_characters.valid?).to be false
+      expect(too_short.valid?).to be false
+      expect(too_long.valid?).to be false
+    end
 
-    expect(okay.valid?).to be true
-    expect(invalid_characters.valid?).to be false
-    expect(too_short.valid?).to be false
-    expect(too_long.valid?).to be false
-  end
+    it "allows LinkedIn username to have hyphens" do
+      okay = build(:user, linked_in: "matthew-leo-kaufman")
+      expect(okay.valid?).to be true
+    end
 
-  it "allows LinkedIn username to have hyphens" do
-    okay = build(:user, linked_in: "matthew-leo-kaufman")
-    expect(okay.valid?).to be true
+    it "creates user with gender pronouns" do
+      user = create :user, gender_pronouns: "she/her"
+
+      expect(user).to be_valid
+    end
   end
 
   context 'Role change' do
@@ -127,7 +134,7 @@ RSpec.describe User, type: :model do
       user = create(:user)
       user.groups = groups
 
-      expect(user.list_groups.include?(groups.first.name)).to be_truthy 
+      expect(user.list_groups.include?(groups.first.name)).to be_truthy
     end
   end
 end


### PR DESCRIPTION
By request from Allison:

Added ability for Census users to record their gender pronouns
-Add input field to registration & edit_user views
-Add column to user table (stored as a string)
-Add tests for all such functionality 
-Expand test coverage for user registration

@neight-allen 