### PR TITLE
Fix aws sdk gem issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,11 @@ source 'https://rubygems.org'
 
 ruby '2.3.0'
 
+gem 'aws-sdk-s3'
 gem "bootstrap-table-rails"
 gem "paperclip", "~> 6.0.0"
 gem 'active_designer'
 gem 'active_model_serializers', '~> 0.10.0'
-gem 'aws-sdk', '~> 2.3'
 gem 'bootstrap-sass'
 gem 'cancancan'
 gem 'coffee-rails', '~> 4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,13 +49,18 @@ GEM
     arel (7.1.4)
     autoprefixer-rails (7.2.5)
       execjs
-    aws-sdk (2.10.117)
-      aws-sdk-resources (= 2.10.117)
-    aws-sdk-core (2.10.117)
+    aws-partitions (1.70.0)
+    aws-sdk-core (3.17.0)
+      aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.10.117)
-      aws-sdk-core (= 2.10.117)
+    aws-sdk-kms (1.5.0)
+      aws-sdk-core (~> 3)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-s3 (1.8.2)
+      aws-sdk-core (~> 3)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.0)
     aws-sigv4 (1.0.2)
     bcrypt (3.1.11)
     bindex (0.5.0)
@@ -294,7 +299,7 @@ PLATFORMS
 DEPENDENCIES
   active_designer
   active_model_serializers (~> 0.10.0)
-  aws-sdk (~> 2.3)
+  aws-sdk-s3
   bootstrap-sass
   bootstrap-table-rails
   brakeman


### PR DESCRIPTION
Why:

* updating paperclip recently changed the dependency needs leading to
  https://app.honeybadger.io/projects/55306/faults/37041991#notice-trace

This change addresses the need by:

* depend on a more specific gem