### PR TITLE
Authorize API calls by default

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,6 +1,7 @@
 module Api::V1
   class ApiController < ActionController::API
-    
+    before_action :doorkeeper_authorize!
+
     private
       def current_resource_owner
         User.find(doorkeeper_token.resource_owner_id) if doorkeeper_token

--- a/app/controllers/api/v1/cohorts_controller.rb
+++ b/app/controllers/api/v1/cohorts_controller.rb
@@ -1,7 +1,5 @@
 class Api::V1::CohortsController < Api::V1::ApiController
-  before_action :doorkeeper_authorize!
-
   def index
-    render json: Cohort.all, root_url: root_url, status: 200 
+    render json: Cohort.all, root_url: root_url, status: 200
   end
 end

--- a/app/controllers/api/v1/roles_controller.rb
+++ b/app/controllers/api/v1/roles_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::RolesController < Api::V1::ApiController
 
   def update
-    role = Role.find(params[:id]) if Role.find(params[:id])
+    role = Role.find(params[:id])
     role.update_attributes(role_params)
     if role.save
       render json: role
@@ -18,7 +18,6 @@ class Api::V1::RolesController < Api::V1::ApiController
       render json: "Unable to delete #{role.name}.".to_json, status: 400
     end
   end
-
 
   private
     def role_params

--- a/app/controllers/api/v1/send_grid/events_controller.rb
+++ b/app/controllers/api/v1/send_grid/events_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::SendGrid::EventsController < Api::V1::ApiController
+  skip_before_action :doorkeeper_authorize!, only: [:update]
+
   def update
     webhook_data = JSON.parse(request.body.read)
     webhook_data.each do |data|

--- a/app/services/ability.rb
+++ b/app/services/ability.rb
@@ -2,7 +2,6 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
-    # Define abilities for the passed in user here.
     user ||= User.new # guest user (not logged in)
 
     if user.has_role?("admin")
@@ -35,24 +34,5 @@ class Ability
     else
       cannot :manage, :all
     end
-
-    #
-    # The first argument to `can` is the action you are giving the user
-    # permission to do.
-    # If you pass :manage it will apply to every action. Other common actions
-    # here are :read, :create, :update and :destroy.
-    #
-    # The second argument is the resource the user can perform the action on.
-    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
-    # class of the resource.
-    #
-    # The third argument is an optional hash of conditions to further filter the
-    # objects.
-    # For example, here the user can only update published articles.
-    #
-    #   can :update, Article, :published => true
-    #
-    # See the wiki for details:
-    # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
   end
 end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -2,11 +2,7 @@ Doorkeeper.configure do
   # Change the ORM that doorkeeper will use (needs plugins)
   orm :active_record
 
-  # This block will be called to check whether the resource owner is authenticated or not.
   resource_owner_authenticator do
-    # fail "Please configure doorkeeper resource_owner_authenticator block located in #{__FILE__}"
-    # Put your resource owner authentication logic here.
-    # Example implementation:
     current_user || redirect_to(new_user_session_url)
   end
 

--- a/spec/requests/api/v1/search_all_request_spec.rb
+++ b/spec/requests/api/v1/search_all_request_spec.rb
@@ -8,9 +8,11 @@ RSpec.describe "General Search API" do
       users.first.cohort = cohort_1
       users.second.cohort = cohort_1
       users.third.cohort = cohort_2
+
+      token = create(:access_token, resource_owner_id: users.first.id).token
       group = create(:group, users: users)
 
-      params = {q: cohort_1.name}
+      params = {q: cohort_1.name, access_token: token}
       get "/api/v1/users/search_all", params: params
 
       json_users = JSON.parse(response.body)
@@ -41,7 +43,8 @@ RSpec.describe "General Search API" do
       users.third.cohort = cohort_3
       group = create(:group, users: users)
 
-      params = {q: "16"}
+      token = create(:access_token, resource_owner_id: users.first.id).token
+      params = {q: "16", access_token: token}
       get "/api/v1/users/search_all", params: params
 
       json_users = JSON.parse(response.body)
@@ -64,7 +67,8 @@ RSpec.describe "General Search API" do
       users.third.roles << role_2
       group = create(:group, users: users)
 
-      params = {q: role_1.name}
+      token = create(:access_token, resource_owner_id: users.first.id).token
+      params = {q: role_1.name, access_token: token}
       get "/api/v1/users/search_all", params: params
 
       json_users = JSON.parse(response.body)
@@ -94,7 +98,8 @@ RSpec.describe "General Search API" do
       users.third.roles << role_3
       group = create(:group, users: users)
 
-      params = {q: "fakerole"}
+      token = create(:access_token, resource_owner_id: users.first.id).token
+      params = {q: "fakerole", access_token: token}
       get "/api/v1/users/search_all", params: params
 
       json_users = JSON.parse(response.body)
@@ -116,7 +121,8 @@ RSpec.describe "General Search API" do
       users.second.groups << group_1
       users.third.groups << group_2
 
-      params = {q: group_1.name}
+      token = create(:access_token, resource_owner_id: users.first.id).token
+      params = {q: group_1.name, access_token: token}
       get "/api/v1/users/search_all", params: params
 
       json_users = JSON.parse(response.body)
@@ -145,7 +151,8 @@ RSpec.describe "General Search API" do
       users.second.groups << group_2
       users.third.groups << group_3
 
-      params = {q: "fakegroup"}
+      token = create(:access_token, resource_owner_id: users.first.id).token
+      params = {q: "fakegroup", access_token: token}
       get "/api/v1/users/search_all", params: params
 
       json_users = JSON.parse(response.body)
@@ -167,7 +174,8 @@ RSpec.describe "General Search API" do
       user_3 = create(:user, first_name: "ali")
       group = create(:group, users: [user_1, user_2, user_3])
 
-      params = {q: "brad"}
+      token = create(:access_token, resource_owner_id: user_1.id).token
+      params = {q: "brad", access_token: token}
       get "/api/v1/users/search_all", params: params
 
       json_users = JSON.parse(response.body)
@@ -193,7 +201,8 @@ RSpec.describe "General Search API" do
       user_3 = create(:user, first_name: "brad", last_name: "green")
       group = create(:group, users: [user_1, user_2, user_3])
 
-      params = {q: "gibberish"}
+      token = create(:access_token, resource_owner_id: user_1.id).token
+      params = {q: "gibberish", access_token: token}
       get "/api/v1/users/search_all", params: params
 
       json_users = JSON.parse(response.body)
@@ -215,7 +224,8 @@ RSpec.describe "General Search API" do
       user_3 = create(:user, last_name: "green")
       group = create(:group, users: [user_1, user_2, user_3])
 
-      params = {q: "schlereth"}
+      token = create(:access_token, resource_owner_id: user_1.id).token
+      params = {q: "schlereth", access_token: token}
       get "/api/v1/users/search_all", params: params
 
       json_users = JSON.parse(response.body)
@@ -242,7 +252,8 @@ RSpec.describe "General Search API" do
     user_3 = create(:user, first_name: "other")
     group = create(:group, users: [user_1, user_2, user_3])
 
-    params = {q: "first last"}
+    token = create(:access_token, resource_owner_id: user_1.id).token
+    params = {q: "first last", access_token: token}
     get "/api/v1/users/search_all", params: params
 
     returned_users = JSON.parse(response.body)

--- a/spec/requests/api/v1/users/roles_remove_request_spec.rb
+++ b/spec/requests/api/v1/users/roles_remove_request_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe "User Roles API" do
       user_1, user_2 = create_list(:user, 2, roles: [role_1, role_2])
 
       headers = {"CONTENT-TYPE" => "application/json"}
-      params = {roles: [role_2.id], users: [user_1.id, user_2.id]}.to_json
+      token = create(:access_token, resource_owner_id: user_1.id).token
+      params = {roles: [role_2.id], users: [user_1.id, user_2.id], access_token: token}.to_json
 
       patch "/api/v1/users/remove_roles", params: params, headers: headers
 

--- a/spec/requests/users_roles_request_spec.rb
+++ b/spec/requests/users_roles_request_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe "User Roles API" do
       user_1, user_2 = create_list(:user, 2, roles: [role_1])
 
       headers = {"CONTENT-TYPE" => "application/json"}
-      params = {roles: [role_2.id], users: [user_1.id, user_2.id]}.to_json
+      token = create(:access_token, resource_owner_id: user_1.id).token
+      params = {roles: [role_2.id], users: [user_1.id, user_2.id], access_token: token}.to_json
 
       patch "/api/v1/users/add_roles", params: params, headers: headers
 


### PR DESCRIPTION
Why:

* API calls can be destructive so we want to authorize them all

This change addresses the need by:

* authorizing the API parent controller forcing children controllers to
  actively skip auth if they need to (such as in the send grid events
  controller)

Part of https://trello.com/c/XkOXjMhS/243-census-api-security-model