### PR TITLE
Support user search from UI

### DIFF
--- a/app/controllers/api/v1/users/search_all_controller.rb
+++ b/app/controllers/api/v1/users/search_all_controller.rb
@@ -1,8 +1,16 @@
 class Api::V1::Users::SearchAllController < Api::V1::ApiController
+  skip_before_action :doorkeeper_authorize!, only: [:index]
+  before_action :require_user_or_doorkeeper_authorize!
 
   def index
     users = User.search_all(params["q"])
     render json: users
+  end
+
+  private
+
+  def require_user_or_doorkeeper_authorize!
+    current_user || doorkeeper_authorize!
   end
 
 end

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -8,7 +8,7 @@ class Cohort
     @raw_cohort = cohort
   end
 
-  def as_json(args)
+  def as_json(args=nil)
     {
       course_id: self.course_id,
       end_date: self.end_date,

--- a/spec/requests/api/v1/search_all_request_spec.rb
+++ b/spec/requests/api/v1/search_all_request_spec.rb
@@ -1,7 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe "General Search API" do
+  include Warden::Test::Helpers
+
   context  "GET api/v1/users/search" do
+    context 'without an access token' do
+      it 'authenticates logged in users' do
+        user = create :user
+        login_as(user, scope: Devise::Mapping.find_scope!(user))
+
+        get "/api/v1/users/search_all", params: { q: 'foo' }
+
+        expect(response.status).to eq 200
+      end
+
+      it 'rejects guest users' do
+        get "/api/v1/users/search_all", params: { q: 'foo' }
+        expect(response.status).to eq 401
+      end
+    end
+
     it "searches by cohort and returns users with first, last and groups" do
       cohort_1 = Cohort.new(OpenStruct.new(id: 1234, status: "closed", name: "1608-BE"))
       cohort_2 = Cohort.new(OpenStruct.new(id: 1230, status: "open", name: "1703-FE"))


### PR DESCRIPTION
Why:

* we recently forced all API endpoint to require a doorkeeper token to
  prevent leaking data. It turns out we use the user.search_all endpoint
  from the UI, which is called by a logged in user so we need to allow
  logged in users as well as tokens to call this endpoint

This change addresses the need by:

* updating this one endpoint to first check if there is a current user.
  If there is, the request is okay, otherwise check the doorkeeper auth.
  For now, this endpoint is the only one with dual auth so the logic
  lives there

https://trello.com/c/psgQxgAn/254-update-api-auth-for-searchall-to-work-for-logged-in-admins