### PR TITLE
fix timeout on /users page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,11 +4,10 @@ module ApplicationHelper
   end
 
   def user_is_admin?
-    current_user.roles.where(name: 'admin').exists? if current_user
+    current_user.has_role?("admin") if current_user
   end
 
   def user_is_staff?
-    current_user.roles.where(name: 'staff').exists? if current_user
+    current_user.has_role?("staff") if current_user
   end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,7 +60,7 @@ class User < ApplicationRecord
   end
 
   def has_role?(role)
-    roles.where(name: "#{role}").exists?
+    roles.any? { |user_role| user_role.name == role }
   end
 
   def self.search_by_name(term)

--- a/app/models/users_presenter.rb
+++ b/app/models/users_presenter.rb
@@ -3,7 +3,7 @@ class UsersPresenter
   def initialize(cohort_id = nil)
     @cohort_id = cohort_id
     @all_selected = 'All Users'
-    @all_users = User.all
+    @all_users = User.all.includes(:roles)
   end
 
   def cohorts
@@ -13,7 +13,7 @@ class UsersPresenter
   def users
     if @cohort_id != '' && @cohort_id
       cohort = Cohort.find(@cohort_id)
-      cohort.users
+      cohort.users.includes(:roles)
     else
       @all_users
     end


### PR DESCRIPTION
Why:

* the /users (community) page was timing out because of an n+1 on roles

This change addresses the need by:

* updating the queries to eager load the users' roles and to check in
  memory if the role exists. It reduces us down to 4 queries instead of
  2 + count(users) queries

https://trello.com/c/wWbyeK3n/255-fix-n1-query-on-https-loginturingio-users