### PR TITLE
Fix other performance issue on /users page

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,7 +56,7 @@ class User < ApplicationRecord
   end
 
   def cohort
-    Cohort.find(self.cohort_id)
+    @cohort ||= Cohort.find(self.cohort_id)
   end
 
   def has_role?(role)

--- a/app/models/users_presenter.rb
+++ b/app/models/users_presenter.rb
@@ -7,7 +7,21 @@ class UsersPresenter
   end
 
   def cohorts
-    Cohort.all
+    @cohorts ||= Cohort.all
+  end
+
+  def cohort_name_for_user(user:)
+    user_cohort = cohort(cohort_id: user.cohort_id)
+
+    if user_cohort
+      user_cohort.name
+    else
+      "n/a"
+    end
+  end
+
+  def cohort(cohort_id:)
+    cohorts.find { |cohort| cohort.id == cohort_id }
   end
 
   def users

--- a/app/views/users/_user_row.html.erb
+++ b/app/views/users/_user_row.html.erb
@@ -4,6 +4,7 @@
   <% else %>
     <td class="user-name"><%= user.full_name %></td>
   <% end %>
+
   <td class="user-slack"><%= user.slack %></td>
-  <td class="user-cohort"><%= user.cohort_name %></td>
+  <td class="user-cohort"><%= @presenter.cohort_name_for_user(user: user) %></td>
 </tr>


### PR DESCRIPTION
Why:

* follow up to f1c044d83b89379ce03c90b0d0fa77eaea4bbc1b, the /users page
  was still slow.

This change addresses the need by:

* it was slow because we had an n+1 query to fetch the cohort for each
  user (to get its name)
* this change updates the UsersPresenter to fetch the cohorts once and
  then in memory filter to get the user's cohort

https://trello.com/c/wWbyeK3n/255-fix-n1-query-on-https-loginturingio-users