### PR TITLE
Update API endpoints to return JSON in error cases

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -2,6 +2,16 @@ module Api::V1
   class ApiController < ActionController::API
     before_action :doorkeeper_authorize!
 
+    # return json bodies for not found errors
+    rescue_from ActiveRecord::RecordNotFound do |error|
+      render json: { errors: ["Record Not Found"] }, status: 404
+    end
+
+    # return json bodies for doorkeeper authorization errors
+    def doorkeeper_unauthorized_render_options(error: nil)
+      { json: { errors: ["Not authorized"] } }
+    end
+
     private
 
     def current_resource_owner

--- a/spec/requests/api/v1/users/user_request_spec.rb
+++ b/spec/requests/api/v1/users/user_request_spec.rb
@@ -2,26 +2,11 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::CredentialsController do
   context "Request is sent _without_ authorization credentials" do
-    it "returns a 401 (unauthorized) response status" do
+    it "returns a 401 (unauthorized) JSON response" do
       get api_v1_user_credentials_path
 
       expect(response).to have_http_status(401)
-    end
-  end
-
-  context "Request is sent _with_ authorization credentials" do
-    it "returns info for all users" do
-      user = create :user
-      token = create(:access_token, resource_owner_id: user.id).token
-
-      get  api_v1_user_credentials_path, params: {access_token: token}
-      response_user = JSON.parse(response.body)
-
-      expect(response).to have_http_status(200)
-      expect(response_user["first_name"]).to eq(user["first_name"])
-      expect(response_user["last_name"]).to eq(user["last_name"])
-      expect(response_user["cohort"]["name"]).to eq(user.cohort.name)
-      expect(response_user["id"]).to eq(user.id)
+      expect(JSON.parse(response.body)["errors"]).to match_array(["Not authorized"])
     end
   end
 end

--- a/spec/requests/api/v1/users/users_request_spec.rb
+++ b/spec/requests/api/v1/users/users_request_spec.rb
@@ -42,9 +42,9 @@ RSpec.describe Api::V1::UsersController do
       expect(response_users.last["roles"]).to eq([])
     end
   end
+
   context "Request for user by id is sent _with_ authorization credentials" do
     it "returns info for requested user" do
-
       test_root_url = "http://www.example.com/"
       user = create(:enrolled_user, cohort_id: 1234)
       create_list(:group, 1, name: "dummygroup", users: [user])
@@ -68,7 +68,6 @@ RSpec.describe Api::V1::UsersController do
       expect(json_user["git_hub"]).to eq(user.git_hub)
       expect(json_user["groups"].first).to eq(user.groups.first.name)
       expect(json_user["roles"].first).to eq(user.roles.first.name)
-
     end
   end
 end


### PR DESCRIPTION
Why:

* we want our developers to be able to gracefully handle error cases

This change addresses the need by:

* updating the API controller to return JSON bodies for auth errors and
  for 404 cases per
  https://github.com/doorkeeper-gem/doorkeeper/wiki/Customizing-the-response-body-when-unauthorized