### PR TITLE
Properly scope the API Admin controller

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -2,7 +2,7 @@ class AdminController < ApplicationController
   before_action :is_admin?
 
   def is_admin?
-    unless current_user && current_user.roles.where(name: 'admin').exists?
+    unless current_user && current_user.has_role?('admin')
       render :file => 'public/404.html', :status => :not_found, :layout => false
     end
   end

--- a/app/controllers/api/v1/admin/invitations_controller.rb
+++ b/app/controllers/api/v1/admin/invitations_controller.rb
@@ -1,5 +1,5 @@
 module Api::V1::Admin
-  class InvitationsController < AdminController
+  class InvitationsController < Api::V1::Admin::AdminController
     def create
       manager = InvitationManager.new(
         invitation_params,

--- a/spec/requests/api/v1/admin/invitations_spec.rb
+++ b/spec/requests/api/v1/admin/invitations_spec.rb
@@ -13,9 +13,33 @@ RSpec.describe Api::V1::Admin::InvitationsController do
     end
   end
 
+  context "Request is sent _with_ non-admin authorization credentials" do
+    it "returns a 403 (unauthorized) response status" do
+      user = create :user
+      application = create(
+        :application,
+        owner: user
+      )
+      token = create(
+        :access_token,
+        resource_owner_id: user.id,
+        application: application
+      ).token
+      invitee_email = "invitee@example.com"
+
+      expect {
+        post api_v1_admin_invitations_path, params: {
+          access_token: token,
+          invitation:  { email: invitee_email }
+        }
+      }.not_to change { Invitation.where(email: invitee_email).count }
+
+      expect(response.status).to eq 403
+    end
+  end
+
   context "Request is sent _with_ authorization credentials" do
     it "creates the invitation" do
-      user_cohort = Cohort.new(OpenStruct.new(id: 1234, name: "1609-be"))
       user = create :user
       user.roles << Role.find_or_create_by!(name: "admin")
       application = create(


### PR DESCRIPTION
We were getting CSRF errors once deployed when calling the invitations
create API, which didn't make sense. Turned out the
InvitationsController had been namespaced incorrectly to the HTML admin
controller as opposed to the API admin controller. This issue should
properly auth as well as fix the csrf issue.

Follow on from
https://trello.com/c/xVljwMcC/257-api-for-creating-an-invite-to-census-enroll