### PR TITLE
Attempt to fix admin controller namespace issues

### DIFF
--- a/app/controllers/api/v1/admin/admin_controller.rb
+++ b/app/controllers/api/v1/admin/admin_controller.rb
@@ -1,7 +1,5 @@
-module Api::V1
-  class Admin::AdminController < ApiController
-    before_action do
-      doorkeeper_authorize! :admin
-    end
+class Api::V1::Admin::AdminController < Api::V1::ApiController
+  before_action do
+    doorkeeper_authorize! :admin
   end
 end


### PR DESCRIPTION
Why:

* after deploying 6e15618ec12dd8b4eb071f18e2ee926cb7f6a6d6, heroku boot
  up failed (couldn't reproduce locally) with

```
ate changed from up to starting
Apr 18 11:49:27 census-app-staging app/web.1:
/app/vendor/bundle/ruby/2.3.0/gems/activesupport-5.0.6/lib/active_support/dependencies.rb:512:in
`load_missing_constant': Unable to autoload constant
Api::V1::Admin::AdminController, expected
/app/app/controllers/api/v1/admin/admin_controller.rb to define it
(LoadError)
```

note the odd `/app/app`

This change addresses the need by:

* using colon namespacing instead of module namespacing to see if that
  makes the autoloading happy.