### PR TITLE
Remove cohorts from registration form

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -24,8 +24,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # POST /resource
   def create
     if valid_invitation_code?
-      @user = User.new(invited_user_params)
       invitation = Invitation.find_by(invitation_code: session[:invitation_code])
+      @user = User.new(invited_user_params.merge(email: invitation.email, cohort_id: invitation.cohort_id))
       @user.roles << invitation.role
       @user.skip_confirmation!
 
@@ -57,20 +57,18 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
     def invited_user_params
       params.require(:user).permit(
-                                    :email,
-                                    :first_name,
-                                    :last_name,
-                                    :twitter,
-                                    :linked_in,
-                                    :git_hub,
-                                    :slack,
-                                    :cohort_id,
-                                    :password,
-                                    :password_confirmation,
-                                    :image,
-                                    :stackoverflow,
-                                    :gender_pronouns
-                                    )
+        :first_name,
+        :gender_pronouns,
+        :git_hub,
+        :image,
+        :last_name,
+        :linked_in,
+        :password,
+        :password_confirmation,
+        :slack,
+        :stackoverflow,
+        :twitter
+      )
     end
 
     def valid_invitation_code?

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -11,7 +11,7 @@
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name), multipart: true) do |f| %>
         <%= devise_error_messages! %>
 
-        <%= render 'shared/registration_fields', f: f, cohorts: @cohorts %>
+        <%= render 'shared/registration_fields', f: f, cohorts: @cohorts, show_cohorts: false %>
 
         <div class="form-group">
           <div class="field">

--- a/app/views/shared/_registration_fields.html.erb
+++ b/app/views/shared/_registration_fields.html.erb
@@ -65,18 +65,20 @@
   </div>
 </div>
 
-<div class="form-group">
-  <div class="field">
-    <%= f.label :cohort_id %><br />
-    <% if user_is_admin? && @user.cohort %>
-      <%= f.select :cohort_id, options_from_collection_for_select(cohorts, "id", "name", "#{@user.cohort.id}"), class:"form-control" %>
-    <% elsif @user.cohort %>
-      <%= f.select :cohort_id, options_from_collection_for_select([@user.cohort], "id", "name", "#{@user.cohort.id}"),class:"form-control" %>
-    <% else %>
-      <%= f.select :cohort_id, options_from_collection_for_select(cohorts, "id", "name"), include_blank: true, class:"form-control" %>
-    <% end %>
+<% if show_cohorts %>
+  <div class="form-group">
+    <div class="field">
+      <%= f.label :cohort_id %><br />
+      <% if user_is_admin? && @user.cohort %>
+        <%= f.select :cohort_id, options_from_collection_for_select(cohorts, "id", "name", "#{@user.cohort.id}"), class:"form-control" %>
+      <% elsif @user.cohort %>
+        <%= f.select :cohort_id, options_from_collection_for_select([@user.cohort], "id", "name", "#{@user.cohort.id}"),class:"form-control" %>
+      <% else %>
+        <%= f.select :cohort_id, options_from_collection_for_select(cohorts, "id", "name"), include_blank: true, class:"form-control" %>
+      <% end %>
+    </div>
   </div>
-</div>
+<% end %>
 
 <div class="form-group">
   <div class="field">

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,7 +1,7 @@
 <div class='container well col-md-4 col-md-offset-4'>
   <h2>Edit Profile</h2>
   <%= form_for @user do |f| %>
-    <%= render 'shared/registration_fields', f: f, cohorts: @cohorts %>
+    <%= render 'shared/registration_fields', f: f, cohorts: @cohorts, show_cohorts: true %>
     <div class="actions">
       <%= f.submit "Update", class: 'btn btn-default btn-xs' %>
     </div>

--- a/spec/acceptance/user/completes_max_registration_spec.rb
+++ b/spec/acceptance/user/completes_max_registration_spec.rb
@@ -20,8 +20,6 @@ RSpec.feature 'User signs up' do
     fill_in 'user[slack]', with: user[:slack]
     fill_in 'user[stackoverflow]', with: user[:stackoverflow]
 
-    find("option[value='#{cohort.id}']").select_option
-
     click_button 'Sign up'
 
     help_message = 'You have succesfully signed up!'

--- a/spec/features/invited_guest_registers_spec.rb
+++ b/spec/features/invited_guest_registers_spec.rb
@@ -23,8 +23,6 @@ RSpec.feature 'Invited user features' do
     invite_path = invite.generate_url(new_user_registration_url)
     visit invite_path
 
-    expect(page).to have_select('user_cohort_id', selected: '1608-BE')
-
     fill_in 'Password*', with: 'password'
     fill_in 'Password Confirmation*', with: 'password'
     fill_in 'First Name*', with: 'Jeff'

--- a/spec/features/users/basic_registration_spec.rb
+++ b/spec/features/users/basic_registration_spec.rb
@@ -63,7 +63,6 @@ RSpec.feature 'User signs up' do
     expect(page).to have_content("StackOverflow")
     expect(page.find_field("stack_overflow-field")).to be_truthy
 
-    expect(page).to have_content("Cohort")
     expect(page).to have_content("Upload an image")
   end
 


### PR DESCRIPTION
the sign up flow after getting invited to census (with enroll access)
has no cohort set (since they are not yet enrolled) but the sing up page
in census allows the user to pick a cohort. We want to remove that
cohort selection since they are going to do that in Enroll.

we also want enrollment to always happen in Enroll so we're removing the
cohort dropdown from the registration for entirely. It is still seen on
the user edit page (which admins can use).

https://trello.com/c/26SqGzIn/322-as-an-invited-user-i-should-not-be-able-to-pick-a-cohort