### PR TITLE
Upgrade Ruby to 2.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  2.3.0
+  2.4.1
 services:
   - postgresql
 before_script:

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.3.0'
+ruby '2.4.1'
 
 gem 'aws-sdk-s3'
 gem "bootstrap-table-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -345,7 +345,7 @@ DEPENDENCIES
   web-console
 
 RUBY VERSION
-   ruby 2.3.0p0
+   ruby 2.4.1p111
 
 BUNDLED WITH
    1.16.1

--- a/spec/acceptance/filter_users_spec.rb
+++ b/spec/acceptance/filter_users_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.feature 'Filter users by cohort' do
   scenario 'by selecting cohort from dropdown', js: true do
-    cohort = Cohort.new(OpenStruct.new(id: 1234, status: "closed", name: "1606"))
-    cohort_2 = Cohort.new(OpenStruct.new(id: 1230, status: "open", name: "1608"))
+    cohort = Cohort.new(RemoteCohort.new(id: 1234, status: "closed", name: "1606"))
+    cohort_2 = Cohort.new(RemoteCohort.new(id: 1230, status: "open", name: "1608"))
     stub_cohorts_with([cohort, cohort_2])
     create(:enrolled_user, cohort_id: cohort.id)
     user = create(:enrolled_user, cohort_id: cohort_2.id)

--- a/spec/acceptance/user/completes_max_registration_spec.rb
+++ b/spec/acceptance/user/completes_max_registration_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'User signs up' do
   scenario 'by completing full registration' do
-    cohort = Cohort.new(OpenStruct.new(id: 1234, status: "open", name: "1608-BE"))
+    cohort = Cohort.new(RemoteCohort.new(id: 1234, status: "open", name: "1608-BE"))
     allow(Cohort).to receive(:all).and_return([cohort])
     user = attributes_for(:user)
     role = create :role, name: 'active student'

--- a/spec/acceptance/user/edit_spec.rb
+++ b/spec/acceptance/user/edit_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.feature 'Edit all user attributes' do
   scenario 'by submitting edit user form' do
-    cohort_1 = Cohort.new(OpenStruct.new(id: 1234, status: "open", name: "1608-BE"))
-    cohort_2 = Cohort.new(OpenStruct.new(id: 1230, status: "open", name: "1703-FE"))
+    cohort_1 = Cohort.new(RemoteCohort.new(id: 1234, status: "open", name: "1608-BE"))
+    cohort_2 = Cohort.new(RemoteCohort.new(id: 1230, status: "open", name: "1703-FE"))
     allow(Cohort).to receive(:all).and_return([cohort_1, cohort_2])
     user   = create( :enrolled_user,
                      first_name: "Joe",

--- a/spec/features/admins/admin_can_see_all_cohorts_spec.rb
+++ b/spec/features/admins/admin_can_see_all_cohorts_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 RSpec.feature "Admin user" do
   it "can see all cohorts already created" do
     admin = create :admin
-    cohort_1 = Cohort.new(OpenStruct.new(id: 1234, name: "1606-be"))
-    cohort_2 = Cohort.new(OpenStruct.new(id: 1230, name: "1606-fe"))
-    cohort_3 = Cohort.new(OpenStruct.new(id: 1231, name: "1608-be"))
+    cohort_1 = Cohort.new(RemoteCohort.new(id: 1234, name: "1606-be"))
+    cohort_2 = Cohort.new(RemoteCohort.new(id: 1230, name: "1606-fe"))
+    cohort_3 = Cohort.new(RemoteCohort.new(id: 1231, name: "1608-be"))
     stub_cohorts_with([cohort_1, cohort_2, cohort_3])
 
     sign_in admin

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Cohort, type: :model do
   it "can update student roles" do
-    cohort = Cohort.new(OpenStruct.new(id: 1234, status: "open"))
+    cohort = Cohort.new(RemoteCohort.new(id: 1234, status: "open"))
     user = create :active_student, cohort_id: cohort.id
     create :role, name: "active student"
     create :role, name: "graduated"
@@ -12,7 +12,7 @@ RSpec.describe Cohort, type: :model do
   end
 
   it "doesn't update students with wonky roles" do
-    cohort = Cohort.new(OpenStruct.new(id: 1234, status: "open"))
+    cohort = Cohort.new(RemoteCohort.new(id: 1234, status: "open"))
     create :role, name: "active student"
     create :role, name: "graduated"
     create :role, name: "enrolled"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,6 +31,18 @@ RSpec.configure do |config|
   config.include Paperclip::Shoulda::Matchers
 end
 
+class RemoteCohort
+  attr_reader :id, :end_date, :name, :start_date, :status
+
+  def initialize(id:, end_date: DateTime.new, name: "cohort-name", start_date: DateTime.new, status: "open")
+    @id = id
+    @end_date = end_date
+    @name = name
+    @start_date = start_date
+    @status = status
+  end
+end
+
 def login(user)
   visit root_path
   click_link 'Login'

--- a/spec/requests/api/v1/cohorts_request_spec.rb
+++ b/spec/requests/api/v1/cohorts_request_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe Api::V1::CohortsController do
 
   context "Request is sent _with_ authorization credentials" do
     it "returns all cohorts" do
-      user_cohort = Cohort.new(OpenStruct.new(id: 1234, name: "1609-be"))
+      user_cohort = Cohort.new(RemoteCohort.new(id: 1234, name: "1609-be"))
       user = create :user
       token = create(:access_token, resource_owner_id: user.id).token
-      cohort_1 = Cohort.new(OpenStruct.new(id: 1232, name: "1606-be"))
-      cohort_2 = Cohort.new(OpenStruct.new(id: 1230, name: "1606-fe"))
-      cohort_3 = Cohort.new(OpenStruct.new(id: 1231, name: "1608-be"))
+      cohort_1 = Cohort.new(RemoteCohort.new(id: 1232, name: "1606-be"))
+      cohort_2 = Cohort.new(RemoteCohort.new(id: 1230, name: "1606-fe"))
+      cohort_3 = Cohort.new(RemoteCohort.new(id: 1231, name: "1608-be"))
       stub_cohorts_with([user_cohort, cohort_1, cohort_2, cohort_3])
 
       get '/api/v1/cohorts', params: {access_token: token}

--- a/spec/requests/api/v1/search_all_request_spec.rb
+++ b/spec/requests/api/v1/search_all_request_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe "General Search API" do
     end
 
     it "searches by cohort and returns users with first, last and groups" do
-      cohort_1 = Cohort.new(OpenStruct.new(id: 1234, status: "closed", name: "1608-BE"))
-      cohort_2 = Cohort.new(OpenStruct.new(id: 1230, status: "open", name: "1703-FE"))
+      cohort_1 = Cohort.new(RemoteCohort.new(id: 1234, status: "closed", name: "1608-BE"))
+      cohort_2 = Cohort.new(RemoteCohort.new(id: 1230, status: "open", name: "1703-FE"))
       stub_cohorts_with([cohort_1, cohort_2])
       users = create_list(:user, 3)
       users.first.cohort_id = cohort_1.id
@@ -51,9 +51,9 @@ RSpec.describe "General Search API" do
     end
 
     it "returns users matching cohort partial search query" do
-      cohort_1 = Cohort.new(OpenStruct.new(id: 1234, name: "1608"))
-      cohort_2 = Cohort.new(OpenStruct.new(id: 1230, name: "1610"))
-      cohort_3 = Cohort.new(OpenStruct.new(id: 1231, name: "1701"))
+      cohort_1 = Cohort.new(RemoteCohort.new(id: 1234, name: "1608"))
+      cohort_2 = Cohort.new(RemoteCohort.new(id: 1230, name: "1610"))
+      cohort_3 = Cohort.new(RemoteCohort.new(id: 1231, name: "1701"))
       stub_cohorts_with([cohort_1, cohort_2, cohort_3])
 
       users = create_list(:user, 3)

--- a/spec/services/invitation_manager_spec.rb
+++ b/spec/services/invitation_manager_spec.rb
@@ -130,8 +130,8 @@ RSpec.describe InvitationManager do
   it "sets role to active student if student and active cohort" do
     params = { email: "good@example.com", role: "Student", cohort: "1703-FE" }
     cohort_stubs = [
-      Cohort.new(OpenStruct.new(id: 1234, status: "closed", name: "1608-BE")),
-      Cohort.new(OpenStruct.new(id: 1230, status: "open", name: "1703-FE"))
+      Cohort.new(RemoteCohort.new(id: 1234, status: "closed", name: "1608-BE")),
+      Cohort.new(RemoteCohort.new(id: 1230, status: "open", name: "1703-FE"))
     ]
     stub_cohorts_with(cohort_stubs)
     manager = InvitationManager.new(params, user, url)
@@ -143,8 +143,8 @@ RSpec.describe InvitationManager do
   it "sets role to graduated if student and finished cohort" do
     params = { email: "good@example.com", role: "Student", cohort: "1703-FE" }
     cohort_stubs = [
-      Cohort.new(OpenStruct.new(id: 1234, status: "open", name: "1608-BE")),
-      Cohort.new(OpenStruct.new(id: 1230, status: "closed", name: "1703-FE"))
+      Cohort.new(RemoteCohort.new(id: 1234, status: "open", name: "1608-BE")),
+      Cohort.new(RemoteCohort.new(id: 1230, status: "closed", name: "1703-FE"))
     ]
     stub_cohorts_with(cohort_stubs)
     manager = InvitationManager.new(params, user, url)

--- a/spec/support/cohorts_helper.rb
+++ b/spec/support/cohorts_helper.rb
@@ -1,6 +1,6 @@
 def stub_cohorts_with(cohort_stubs = nil)
   allow(Cohort).to receive(:all).and_return(
-    cohort_stubs || [Cohort.new(OpenStruct.new(id: 1234, status: "open", name: "1608-BE"))]
+    cohort_stubs || [Cohort.new(RemoteCohort.new(id: 1234, status: "open", name: "1608-BE"))]
   )
 end
 


### PR DESCRIPTION
Why:

* keep this thing up to date!

This change addresses the need by:

* bumping the Ruby version and also changing the use of `OpenStruct` for
  mocking cohorts from enroll to use a proper `RemoteCohort` class
  defined in tests.

https://trello.com/c/MnoCZrY4/327-upgrade-enroll-ruby-to-241