### PR TITLE
Add Devise lockable

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,14 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable, :confirmable
+  devise(
+    :database_authenticatable,
+    :registerable,
+    :recoverable,
+    :rememberable,
+    :trackable,
+    :validatable,
+    :confirmable,
+    :lockable
+  )
 
   before_validation :twitter,
                     :sanitize_inputs

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -170,24 +170,24 @@ Devise.setup do |config|
   # Defines which strategy will be used to lock an account.
   # :failed_attempts = Locks an account after a number of failed attempts to sign in.
   # :none            = No lock strategy. You should handle locking by yourself.
-  # config.lock_strategy = :failed_attempts
+  config.lock_strategy = :failed_attempts
 
   # Defines which key will be used when locking and unlocking an account
-  # config.unlock_keys = [:email]
+  config.unlock_keys = [:email]
 
   # Defines which strategy will be used to unlock an account.
   # :email = Sends an unlock link to the user email
   # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
   # :both  = Enables both strategies
   # :none  = No unlock strategy. You should handle unlocking by yourself.
-  # config.unlock_strategy = :both
+  config.unlock_strategy = :both
 
   # Number of authentication tries before locking an account if lock_strategy
   # is failed attempts.
-  # config.maximum_attempts = 20
+  config.maximum_attempts = 10
 
   # Time interval to unlock the account if :time is enabled as unlock_strategy.
-  # config.unlock_in = 1.hour
+  config.unlock_in = 6.hour
 
   # Warn on the last attempt before the account is locked.
   # config.last_attempt_warning = true

--- a/db/migrate/20180426223438_add_lockable_to_devise_user.rb
+++ b/db/migrate/20180426223438_add_lockable_to_devise_user.rb
@@ -1,0 +1,8 @@
+class AddLockableToDeviseUser < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :failed_attempts, :integer, default: 0, null: false
+    add_column :users, :unlock_token, :string
+    add_column :users, :locked_at, :datetime
+    add_index :users, :unlock_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180317195113) do
+ActiveRecord::Schema.define(version: 20180426223438) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -138,10 +138,14 @@ ActiveRecord::Schema.define(version: 20180317195113) do
     t.integer  "cohort_id"
     t.string   "stackoverflow"
     t.string   "gender_pronouns"
+    t.integer  "failed_attempts",        default: 0,  null: false
+    t.string   "unlock_token"
+    t.datetime "locked_at"
     t.index ["cohort_id"], name: "index_users_on_cohort_id", using: :btree
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+    t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true, using: :btree
   end
 
   add_foreign_key "affiliations", "groups"


### PR DESCRIPTION
Why:

* we want to prevent brute force password attempts

This change addresses the need by:

* implementing Devise lockable per
  https://github.com/plataformatec/devise/wiki/How-To:-Add-:lockable-to-Users
* passwords can be failed 10 times before being locked out for 6 hours
  or being reset by a token in an email.

https://trello.com/c/OPvAqe1J/340-enable-devise-lockable-for-census