### PR TITLE
Add more params to filter_params

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,1 @@
-# Be sure to restart your server when you modify this file.
-
-# Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [:access_token, :client_secret, :password, :token]


### PR DESCRIPTION
Why:

* we want to not log these sensitive params

This change addresses the need by:

* part of https://trello.com/c/8qHFi6mZ/262-audit-census