### PR TITLE
Adds cohort_id to user serializers

### DIFF
--- a/app/serializers/single_user_serializer.rb
+++ b/app/serializers/single_user_serializer.rb
@@ -3,6 +3,7 @@ class SingleUserSerializer < ActiveModel::Serializer
              :first_name,
              :last_name,
              :cohort,
+             :cohort_id,
              :image_url,
              :email,
              :slack,

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -3,6 +3,7 @@ class UserSerializer < ActiveModel::Serializer
              :first_name,
              :last_name,
              :cohort,
+             :cohort_id,
              :image_url,
              :email,
              :slack,
@@ -31,8 +32,13 @@ class UserSerializer < ActiveModel::Serializer
   end
 
   def cohort
-   {
-     name: object.cohort.present? ? object.cohort.name : ""
-   }
+    if object.cohort.nil?
+      return {}
+    end
+
+    {
+      id: object.cohort.id,
+      name: object.cohort.name
+    }
   end
 end

--- a/spec/requests/api/v1/users/users_request_spec.rb
+++ b/spec/requests/api/v1/users/users_request_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe Api::V1::UsersController do
       expect(json_user["first_name"]).to eq(user["first_name"])
       expect(json_user["last_name"]).to eq(user["last_name"])
       expect(json_user["cohort"]).to eq(user.cohort.name)
+      expect(json_user["cohort_id"]).to eq(user.cohort.id)
       expect(json_user["image_url"]).to eq(test_root_url + user.image.url)
       expect(json_user["id"]).to eq(user.id)
       expect(json_user["email"]).to eq(user.email)


### PR DESCRIPTION
Why:

* to make it easy for client consumers to get the user's cohort and make
  it symmetric when we pass in a new cohort_id upon updating a user's
  cohort

This change addresses the need by:

* adding `cohort_id` to the two user serializers

https://trello.com/c/3RPuKCDC/315-update-census-user-api-endpoint-to-return-cohort-id