### PR TITLE
Allow enroll-elligible user from Apply to access the profile

### DIFF
--- a/app/services/ability.rb
+++ b/app/services/ability.rb
@@ -18,7 +18,7 @@ class Ability
       can :update, Affiliation
       can :manage, Doorkeeper::Application, owner_id: user.id
       cannot :manage, Invitation
-    elsif user.has_role?("enrolled")
+    elsif user.has_role?("enrolled") || user.has_role?(Role::ENROLL_ELLIGIBLE_ROLE_NAME)
       can :create, User
       can :update, User, id: user.id
       can :read, User, id: user.id

--- a/spec/services/ability_spec.rb
+++ b/spec/services/ability_spec.rb
@@ -12,6 +12,20 @@ RSpec.describe 'User abilities:' do
     end
   end
 
+  context 'invitee user who has not yet enrolled' do
+    it 'can manage most functionality' do
+      user = create :user
+      role = create :role, name: Role::ENROLL_ELLIGIBLE_ROLE_NAME
+      user.roles << role
+      ability = Ability.new(user)
+
+      expect(ability.can? :read, User).to eq(true)
+      expect(ability.can? :manage, Doorkeeper::Application, user_id: user.id).to eq(false)
+      expect(ability.can? :delete, User).to eq(false)
+      expect(ability.can? :manage, UserRole).to eq(false)
+    end
+  end
+
   context 'enrolled or active student user' do
     it 'can manage most functionality' do
       user = create :user


### PR DESCRIPTION
Why:

* when a user is invited in Apply, we invite them in Census (changes
  introduced in https://github.com/turingschool/apply/pull/305 and
  https://github.com/turingschool-projects/census/pull/242). The issue
  is that the enroll-elligible user was not able to access any resources
  (not even their user profile so they got a 404 page after signing up)

This change addresses the need by:

* updating the `ability` class to allow this user to behave as if they
  are enrolled. We could consider scoping down access further for this
  type of user but it seems harmless at this point to allow them to access
  these resources.

In support of
https://trello.com/c/eYxH7Rvm/320-update-apply-to-trigger-invited-applicants-via-census