### PR TITLE
Log the current user id when present

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -30,6 +30,17 @@ module Census
       enable_starttls_auto: true
     }
 
+    config.log_tags = [
+      :request_id,
+      :subdomain,
+      ->(req) {
+        session_key = (Rails.application.config.session_options || {})[:key]
+        session_data = req.cookie_jar.encrypted[session_key] || {}
+        user_id = session_data["warden.user.user.key"]&.first&.first || "guest"
+        "user: #{user_id.to_s}"
+      }
+    ]
+
     config.middleware.insert_before 0, Rack::Cors do
       allow do
         origins '*'


### PR DESCRIPTION
Why:

* similarly to https://github.com/turingschool/apply/pull/316 we want to
  have a better idea of when which users are doing what.

This change addresses the need by:

* adding `config.log_tags` config in all environments adding the
  `request_id`, the `subdomain`, and the current `user_id` if any.
* logs will now look like:

```
[147a87e8-23a6-4ed0-87a1-d21f6340d39e] [user: 5210] Completed 200 OK in
982ms (Views: 956.8ms | ActiveRecord: 3.1ms)
```

https://trello.com/c/KZoF1gID/363-add-metadata-to-census-logging