### PR TITLE
Log log_tags properly in staging and production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,9 +46,6 @@
   # when problems arise.
   config.log_level = :debug
 
-  # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
-
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -46,9 +46,6 @@
   # when problems arise.
   config.log_level = :debug
 
-  # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
-
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 


### PR DESCRIPTION
Why:

* https://github.com/turingschool-projects/census/pull/285 introduced
  more log_tags but there were overrides in staging and production that
  were stomping on them.

This change addresses the need by:

* removing the staging and production specific config

https://trello.com/c/KZoF1gID/363-add-metadata-to-census-logging