### PR TITLE
Accept name on invitation creation via API

### DIFF
--- a/app/controllers/api/v1/admin/invitations_controller.rb
+++ b/app/controllers/api/v1/admin/invitations_controller.rb
@@ -20,6 +20,7 @@ module Api::V1::Admin
     def invitation_params
       {
         email: params[:invitation][:email],
+        name: params[:invitation][:name],
         role: "Invitee"
       }
     end

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -1,12 +1,12 @@
 class InvitationMailer < ApplicationMailer
   def invite(invitation, url)
-    @email = invitation.email
+    @salutation_name = invitation.name
     @url = invitation.generate_url(url)
     enroll_elligible = invitation.enroll_elligible?
     mail(
       to: @email,
       bcc: ['jeff@turing.io', 'erin@turing.io'],
-      subject: "Welcome to Turing",
+      subject: enroll_elligible ? "Welcome to Turing, #{@salutation_name}" : "Welcome to Turing",
       template_name: enroll_elligible ? "invite_with_enroll" : "invite"
     )
   end

--- a/app/services/invitation_manager.rb
+++ b/app/services/invitation_manager.rb
@@ -6,6 +6,7 @@ class InvitationManager
     @cohort = params[:cohort] || ""
     @role = find_role(params[:role])
     @emails = params[:email].split(",").map{|e| e.strip}
+    @name = params[:name] # NB: name should be used only when used with a single email (via API)
     @user = user
     @url = url
     @bad_emails = process_emails if @role
@@ -65,7 +66,7 @@ class InvitationManager
 
     def process_emails
       emails.reduce([]) do |bad_emails, email|
-        invitation = @user.invitations.new(email: email, status: 0, role: @role)
+        invitation = @user.invitations.new(email: email, name: @name, status: 0, role: @role)
         invitation.cohort_id = Cohort.find_by_name(@cohort).id unless @cohort.empty?
         invitation.save ? invitation.send!(@url) : bad_emails << email
         bad_emails

--- a/app/views/invitation_mailer/invite_with_enroll.html.erb
+++ b/app/views/invitation_mailer/invite_with_enroll.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <p>
-    <%= "Hi #{@email}," %>
+    <%= "Hi #{@salutation_name}," %>
   </p>
   <p>
   We are happy to inform you that you have been accepted to the Turing School

--- a/db/migrate/20180517192027_add_name_to_invitations.rb
+++ b/db/migrate/20180517192027_add_name_to_invitations.rb
@@ -1,0 +1,5 @@
+class AddNameToInvitations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :invitations, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,142 +10,143 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180426223438) do
+ActiveRecord::Schema.define(version: 2018_05_17_192027) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "affiliations", force: :cascade do |t|
-    t.integer  "user_id"
-    t.integer  "group_id"
+  create_table "affiliations", id: :serial, force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "group_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["group_id"], name: "index_affiliations_on_group_id", using: :btree
-    t.index ["user_id"], name: "index_affiliations_on_user_id", using: :btree
+    t.index ["group_id"], name: "index_affiliations_on_group_id"
+    t.index ["user_id"], name: "index_affiliations_on_user_id"
   end
 
-  create_table "cohorts", force: :cascade do |t|
-    t.string   "name"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
-    t.integer  "status",     default: 0
+  create_table "cohorts", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "status", default: 0
   end
 
-  create_table "groups", force: :cascade do |t|
-    t.string   "name"
+  create_table "groups", id: :serial, force: :cascade do |t|
+    t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "invitations", force: :cascade do |t|
-    t.integer  "status"
-    t.string   "email"
-    t.string   "invitation_code"
-    t.integer  "user_id"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
-    t.integer  "role_id"
-    t.integer  "cohort_id"
-    t.index ["cohort_id"], name: "index_invitations_on_cohort_id", using: :btree
-    t.index ["role_id"], name: "index_invitations_on_role_id", using: :btree
-    t.index ["user_id"], name: "index_invitations_on_user_id", using: :btree
+  create_table "invitations", id: :serial, force: :cascade do |t|
+    t.integer "status"
+    t.string "email"
+    t.string "invitation_code"
+    t.integer "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "role_id"
+    t.integer "cohort_id"
+    t.string "name"
+    t.index ["cohort_id"], name: "index_invitations_on_cohort_id"
+    t.index ["role_id"], name: "index_invitations_on_role_id"
+    t.index ["user_id"], name: "index_invitations_on_user_id"
   end
 
-  create_table "oauth_access_grants", force: :cascade do |t|
-    t.integer  "resource_owner_id", null: false
-    t.integer  "application_id",    null: false
-    t.string   "token",             null: false
-    t.integer  "expires_in",        null: false
-    t.text     "redirect_uri",      null: false
-    t.datetime "created_at",        null: false
+  create_table "oauth_access_grants", id: :serial, force: :cascade do |t|
+    t.integer "resource_owner_id", null: false
+    t.integer "application_id", null: false
+    t.string "token", null: false
+    t.integer "expires_in", null: false
+    t.text "redirect_uri", null: false
+    t.datetime "created_at", null: false
     t.datetime "revoked_at"
-    t.string   "scopes"
-    t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true, using: :btree
+    t.string "scopes"
+    t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
   end
 
-  create_table "oauth_access_tokens", force: :cascade do |t|
-    t.integer  "resource_owner_id"
-    t.integer  "application_id"
-    t.string   "token",                               null: false
-    t.string   "refresh_token"
-    t.integer  "expires_in"
+  create_table "oauth_access_tokens", id: :serial, force: :cascade do |t|
+    t.integer "resource_owner_id"
+    t.integer "application_id"
+    t.string "token", null: false
+    t.string "refresh_token"
+    t.integer "expires_in"
     t.datetime "revoked_at"
-    t.datetime "created_at",                          null: false
-    t.string   "scopes"
-    t.string   "previous_refresh_token", default: "", null: false
-    t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true, using: :btree
-    t.index ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id", using: :btree
-    t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true, using: :btree
+    t.datetime "created_at", null: false
+    t.string "scopes"
+    t.string "previous_refresh_token", default: "", null: false
+    t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true
+    t.index ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id"
+    t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true
   end
 
-  create_table "oauth_applications", force: :cascade do |t|
-    t.string   "name",                      null: false
-    t.string   "uid",                       null: false
-    t.string   "secret",                    null: false
-    t.text     "redirect_uri",              null: false
-    t.string   "scopes",       default: "", null: false
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
-    t.integer  "owner_id"
-    t.string   "owner_type"
-    t.index ["owner_id", "owner_type"], name: "index_oauth_applications_on_owner_id_and_owner_type", using: :btree
-    t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true, using: :btree
+  create_table "oauth_applications", id: :serial, force: :cascade do |t|
+    t.string "name", null: false
+    t.string "uid", null: false
+    t.string "secret", null: false
+    t.text "redirect_uri", null: false
+    t.string "scopes", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "owner_id"
+    t.string "owner_type"
+    t.index ["owner_id", "owner_type"], name: "index_oauth_applications_on_owner_id_and_owner_type"
+    t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 
-  create_table "roles", force: :cascade do |t|
-    t.string   "name"
+  create_table "roles", id: :serial, force: :cascade do |t|
+    t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "user_roles", force: :cascade do |t|
-    t.integer  "user_id"
-    t.integer  "role_id"
+  create_table "user_roles", id: :serial, force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "role_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["role_id"], name: "index_user_roles_on_role_id", using: :btree
-    t.index ["user_id"], name: "index_user_roles_on_user_id", using: :btree
+    t.index ["role_id"], name: "index_user_roles_on_role_id"
+    t.index ["user_id"], name: "index_user_roles_on_user_id"
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string   "first_name"
-    t.string   "last_name"
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
-    t.string   "reset_password_token"
+  create_table "users", id: :serial, force: :cascade do |t|
+    t.string "first_name"
+    t.string "last_name"
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.inet     "current_sign_in_ip"
-    t.inet     "last_sign_in_ip"
-    t.string   "confirmation_token"
+    t.inet "current_sign_in_ip"
+    t.inet "last_sign_in_ip"
+    t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
-    t.string   "unconfirmed_email"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
-    t.string   "slack"
-    t.string   "cohort"
-    t.string   "twitter"
-    t.string   "linked_in"
-    t.string   "git_hub"
-    t.string   "image_file_name"
-    t.string   "image_content_type"
-    t.integer  "image_file_size"
+    t.string "unconfirmed_email"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "slack"
+    t.string "cohort"
+    t.string "twitter"
+    t.string "linked_in"
+    t.string "git_hub"
+    t.string "image_file_name"
+    t.string "image_content_type"
+    t.integer "image_file_size"
     t.datetime "image_updated_at"
-    t.integer  "cohort_id"
-    t.string   "stackoverflow"
-    t.string   "gender_pronouns"
-    t.integer  "failed_attempts",        default: 0,  null: false
-    t.string   "unlock_token"
+    t.integer "cohort_id"
+    t.string "stackoverflow"
+    t.string "gender_pronouns"
+    t.integer "failed_attempts", default: 0, null: false
+    t.string "unlock_token"
     t.datetime "locked_at"
-    t.index ["cohort_id"], name: "index_users_on_cohort_id", using: :btree
-    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
-    t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
-    t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true, using: :btree
+    t.index ["cohort_id"], name: "index_users_on_cohort_id"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 
   add_foreign_key "affiliations", "groups"

--- a/spec/requests/api/v1/admin/invitations_spec.rb
+++ b/spec/requests/api/v1/admin/invitations_spec.rb
@@ -54,13 +54,14 @@ RSpec.describe Api::V1::Admin::InvitationsController do
         scopes: Oauth::ApplicationsController::ADMIN_SCOPE_NAME
       ).token
       invitee_email = "invitee@example.com"
+      invitee_name = "Margot Tenenbaum"
 
       expect {
         post api_v1_admin_invitations_path, params: {
           access_token: token,
-          invitation:  { email: invitee_email }
+          invitation:  { email: invitee_email, name: invitee_name }
         }
-      }.to change { Invitation.where(email: invitee_email).count }.by(1)
+      }.to change { Invitation.where(email: invitee_email, name: invitee_name).count }.by(1)
 
       expect(response.status).to eq 201
       response_body = JSON.parse(response.body)


### PR DESCRIPTION
Why:

* we need the user's name in the invitation email for UX reasons and
  because staff use the bcc email subject line to handle offline
  processes

This change addresses the need by:

* https://github.com/turingschool/apply/pull/330 updates apply to pass
  the name
* this update hacks the bulk inviter to accept a name. It needs to be
  refactored to make sense in the bulk use case world (from the UI).
  This change is urgent so we'll have to come back and fix it.

https://trello.com/c/xHzkrX5v/377-pass-name-through-to-census-invite