### PR TITLE
Enable Travis caching for Bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 rvm:
   2.5.1
 services:


### PR DESCRIPTION
Why:

* build are slow installing deps

This change addresses the need by:

* enable caching per
  https://docs.travis-ci.com/user/caching/#Caching-directories-(Bundler%2C-dependencies)