### PR TITLE
Use the pretty name in the invite email

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'accounts@turing.io'
+  default from: '"Turing School" <accounts@turing.io>'
   layout 'mailer'
 end


### PR DESCRIPTION
We want users to see a nice Turing brand in the from address