### PR TITLE
Update from address on invitation mailer

### DIFF
--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -3,11 +3,13 @@ class InvitationMailer < ApplicationMailer
     @salutation_name = invitation.name
     @url = invitation.generate_url(url)
     enroll_elligible = invitation.enroll_elligible?
+
     mail(
-      to: invitation.email,
       bcc: ['jeff@turing.io', 'erin@turing.io'],
+      from: '"Turing School" <admissions@turing.io>',
       subject: enroll_elligible ? "Welcome to Turing, #{@salutation_name}" : "Welcome to Turing",
-      template_name: enroll_elligible ? "invite_with_enroll" : "invite"
+      template_name: enroll_elligible ? "invite_with_enroll" : "invite",
+      to: invitation.email
     )
   end
 end


### PR DESCRIPTION
Why:

*  we want to use the more friendly admissions@ email address

Per
https://sendgrid.com/docs/Classroom/Send/How_Emails_Are_Sent/can_i_send_from_multiple_from_addresses.html,
we can use any FROM address we want.

https://trello.com/c/7GHPiRor/378-update-census-from-address-for-invite-emails