### PR TITLE
Fix mailer previews

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,6 +33,7 @@ Rails.application.configure do
   Rails.application.default_url_options = config.action_mailer.default_url_options
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = { address: "localhost", port: 1025 }
+  config.action_mailer.preview_path = "#{Rails.root}/spec/mailers/previews"
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/spec/mailers/previews/invitation_mailer_preview.rb
+++ b/spec/mailers/previews/invitation_mailer_preview.rb
@@ -1,17 +1,20 @@
 class InvitationMailerPreview < ActionMailer::Preview
-  # FIXME(srt32): this import is polluting the mailer preview methods
-
-  include Rails.application.routes.url_helpers
 
   def invite
     invitation = Invitation.last!
     invitation.update!(role: Role.find_or_create_by(name: "student"))
-    InvitationMailer.invite(invitation, new_user_registration_url)
+    InvitationMailer.invite(invitation, invite_url)
   end
 
   def invite_with_enroll
     invitation = Invitation.last!
-    invitation.update!(role: Role.find_or_create_by(name: "invitee"))
-    InvitationMailer.invite(invitation, new_user_registration_url)
+    invitation.update!(role: Role.find_or_create_by(name: Role::ENROLL_ELLIGIBLE_ROLE_NAME))
+    InvitationMailer.invite(invitation, invite_url)
+  end
+
+  private
+
+  def invite_url
+    "localhost:#{ENV.fetch('PORT', 3010)}/users/sign_up"
   end
 end


### PR DESCRIPTION
Why:

* they were broken after the 5.2 upgrade

This change addresses the need by:

* exlicitly set the path to the previews and hardcode the url so we
  don't have to publicly import the url helpers

https://trello.com/c/etC7SYaz/373-mail-previews-are-broken-on-census