### PR TITLE
Eager load assocations on all users endpoint

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::UsersController < Api::V1::ApiController
   before_action :doorkeeper_authorize!
 
   def index
-    render json: User.all, root_url: root_url, status: 200
+    render json: User.all.includes(:roles, :groups), root_url: root_url, status: 200
   end
 
   def show


### PR DESCRIPTION
Why:

* we had n+1's on this endpoint that make it slow

This change addresses the need by:

* eager load some resources used in user serialization