### PR TITLE
Cache cohort data

### DIFF
--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -19,8 +19,10 @@ class Cohort
   end
 
   def self.all
-    result = Enroll::Client.query(CohortsQuery)
-    result.data.cohorts.map { |cohort| Cohort.new(cohort) }
+    Rails.cache.fetch("cohorts-all", expires: 5.minutes) do
+      result = Enroll::Client.query(CohortsQuery)
+      result.data.cohorts.map { |cohort| Cohort.new(cohort) }
+    end
   end
 
   def self.search_by_name(query)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,7 @@
   config.log_level = :debug
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :memory_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -47,7 +47,7 @@
   config.log_level = :debug
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :memory_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
Why:

* on some bulk endpoints, like all users, fetching the cohort data is
  slow from Enroll. The data doesn't change often so let's cache it.

This change addresses the need by:

* uses `Rails.cache.fetch` with memory storage for now to keep it
  simple.