### PR TITLE
Unique index invitations.email

### DIFF
--- a/db/migrate/20180729145051_add_uniq_index_on_invitations_email.rb
+++ b/db/migrate/20180729145051_add_uniq_index_on_invitations_email.rb
@@ -1,0 +1,5 @@
+class AddUniqIndexOnInvitationsEmail < ActiveRecord::Migration[5.2]
+  def change
+    add_index :invitations, :email, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_17_192027) do
+ActiveRecord::Schema.define(version: 2018_07_29_145051) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 2018_05_17_192027) do
     t.integer "cohort_id"
     t.string "name"
     t.index ["cohort_id"], name: "index_invitations_on_cohort_id"
+    t.index ["email"], name: "index_invitations_on_email", unique: true
     t.index ["role_id"], name: "index_invitations_on_role_id"
     t.index ["user_id"], name: "index_invitations_on_user_id"
   end


### PR DESCRIPTION
Why:

* we check it at the model and the invitation flow may be making dups

https://trello.com/c/YqKKKJ9v/415-add-unique-index-on-invitationsemail