### PR TITLE
Use simple mail for invitation resend

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -20,7 +20,7 @@ class InvitationsController < ApplicationController
   end
 
   def update
-    @invitation.send!(new_user_registration_url)
+    @invitation.send!(new_user_registration_url, is_resend: true)
     flash[:success] = "Invitation Re-Sent."
     redirect_to admin_dashboard_path
   end

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -1,8 +1,8 @@
 class InvitationMailer < ApplicationMailer
-  def invite(invitation, url)
+  def invite(invitation, url, is_resend: false)
     @salutation_name = invitation.name
     @url = invitation.generate_url(url)
-    enroll_elligible = invitation.enroll_elligible?
+    enroll_elligible = invitation.enroll_elligible? && !is_resend
 
     mail(
       bcc: ['jeff@turing.io', 'erin@turing.io'],

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -10,8 +10,8 @@ class Invitation < ApplicationRecord
 
   scope :last_five_minutes, -> { where("created_at >=  ?", Time.current - 5.minutes) }
 
-  def send!(url)
-    InvitationMailer.invite(self, url).deliver_now
+  def send!(url, is_resend: false)
+    InvitationMailer.invite(self, url, is_resend: is_resend).deliver_now
     self.mailed!
   end
 

--- a/spec/mailers/previews/invitation_mailer_preview.rb
+++ b/spec/mailers/previews/invitation_mailer_preview.rb
@@ -12,6 +12,12 @@ class InvitationMailerPreview < ActionMailer::Preview
     InvitationMailer.invite(invitation, invite_url)
   end
 
+  def invite_with_enroll_as_resend
+    invitation = Invitation.last!
+    invitation.update!(role: Role.find_or_create_by(name: Role::ENROLL_ELLIGIBLE_ROLE_NAME))
+    InvitationMailer.invite(invitation, invite_url, is_resend: true)
+  end
+
   private
 
   def invite_url


### PR DESCRIPTION
When a user is invited via Apply they get the "welcome to turing" email.

When we resend the invitation (via an admin action in census) it's
confusing for the user to get the same message again.

This change updates the resend endpoint to pass a flag so we send the
simple template upon resending.

Follow up from
https://trello.com/c/0JU5dWA8/414-add-name-to-census-invite-email-from-apply

https://trello.com/c/FQ4158sc/417-update-census-invitation-resend-logic-to-not-send-the-invitation-email