### PR TITLE
Fix cohorts endpoint

### DIFF
--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -2,7 +2,7 @@ require 'forwardable'
 
 class Cohort
   extend Forwardable
-  def_delegators :@raw_cohort, :id, :start_date, :end_date, :name, :status
+  def_delegators :@raw_cohort, :id, :start_date, :name, :status
 
   def initialize(cohort)
     @raw_cohort = cohort
@@ -10,7 +10,6 @@ class Cohort
 
   def as_json(args=nil)
     {
-      end_date: self.end_date,
       id: self.id,
       name: self.name,
       start_date: self.start_date,

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -32,11 +32,10 @@ RSpec.configure do |config|
 end
 
 class RemoteCohort
-  attr_reader :id, :end_date, :name, :start_date, :status
+  attr_reader :id, :name, :start_date, :status
 
-  def initialize(id:, end_date: DateTime.new, name: "cohort-name", start_date: DateTime.new, status: "open")
+  def initialize(id:, name: "cohort-name", start_date: DateTime.new, status: "open")
     @id = id
-    @end_date = end_date
     @name = name
     @start_date = start_date
     @status = status


### PR DESCRIPTION
Why:

* we were calling a field that doens't exist

This change addresses the need by:

* removing the `end_date` field from the API resource

https://app.honeybadger.io/projects/55306/faults/39066625#notice-trace