### PR TITLE
Use env var for controlling ssl redirect requirement

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -73,7 +73,7 @@ Doorkeeper.configure do
   # by default in non-development environments). OAuth2 delegates security in
   # communication to the HTTPS protocol so it is wise to keep this enabled.
   #
-  force_ssl_in_redirect_uri Rails.env.production?
+  force_ssl_in_redirect_uri Rails.application.secrets.require_ssl_redirect_uri
 
   # Specify what grant flows are enabled in array of Strings. The valid
   # strings and the flows they enable are:

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,31 +1,23 @@
-# Be sure to restart your server when you modify this file.
-
-# Your secret key is used for verifying the integrity of signed cookies.
-# If you change this key, all old signed cookies will become invalid!
-
-# Make sure the secret is at least 30 characters and all random,
-# no regular words or you'll be exposed to dictionary attacks.
-# You can use `rails secret` to generate a secure secret key.
-
-# Make sure the secrets in this file are kept private
-# if you're sharing your code publicly.
-
 development:
   secret_key_base: e00a3f09f602f74cb64ed7daead6cf63bdaabb9aa6247443bbcb88be36f3e363443c3e1c448809e714dbd8c5626f2c9f8da3cbc244a8ae3ce1f7adddb0a1f88b
   api_auth_secret: <%= ENV.fetch("API_AUTH_SECRET", "no-api-secret-set") %>
   enroll_graphql_endpoint: <%= ENV.fetch("ENROLL_GRAPHQL_ENDPOINT", "http://localhost:3001/graphql") %>
+  require_ssl_redirect_uri: <%= ENV.fetch('REQUIRE_SSL_REDIRECT_URI', 'false') == 'true' %>
 
 test:
   secret_key_base: ac1e649fcb1f5e6ca0afbc18a83a1851ec5e747f43ad29023e9e53120e069e879b7daaf8f4577e775c730a0a7665b0f30c77dd4505ba12bd8cf0432aeb641a05
   api_auth_secret: <%= ENV.fetch("API_AUTH_SECRET", "no-api-secret-set") %>
   enroll_graphql_endpoint: <%= ENV.fetch("ENROLL_GRAPHQL_ENDPOINT", "http://localhost:3001/graphql") %>
+  require_ssl_redirect_uri: <%= ENV.fetch('REQUIRE_SSL_REDIRECT_URI', 'false') == 'true' %>
 
 staging:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   api_auth_secret: <%= ENV.fetch("API_AUTH_SECRET", "no-api-secret-set") %>
   enroll_graphql_endpoint: <%= ENV.fetch("ENROLL_GRAPHQL_ENDPOINT", "http://localhost:3001/graphql") %>
+  require_ssl_redirect_uri: <%= ENV.fetch('REQUIRE_SSL_REDIRECT_URI', 'false') == 'true' %>
 
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   api_auth_secret: <%= ENV.fetch("API_AUTH_SECRET", "no-api-secret-set") %>
   enroll_graphql_endpoint: <%= ENV.fetch("ENROLL_GRAPHQL_ENDPOINT", "http://localhost:3001/graphql") %>
+  require_ssl_redirect_uri: <%= ENV.fetch('REQUIRE_SSL_REDIRECT_URI', 'true') == 'true' %>


### PR DESCRIPTION
Why:

* we want to move away from a staging env and toggle config via env var

This change addresses the need by:

* removing the `Rails.env.production` check when setting the ssl
  redirect requirement and using a specific env var intead. It'll default
  to true in production and false elsewhere but we can override it if need
  be for testing purposes.

https://trello.com/c/UXJOgSy3/459-remove-staging-env-from-census